### PR TITLE
CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,10 @@ set(HEADERS
 add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 
-add_subdirectory(test)
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()
 
 install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include/rapidfuzz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(rapidfuzz CXX)
 set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
 
 set(SOURCES
 	src/fuzz.txx
@@ -33,14 +34,13 @@ endif()
 
 install(TARGETS rapidfuzz
 	EXPORT rapidfuzzTargets
-	DESTINATION lib
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(FILES ${HEADERS} 
 	DESTINATION include/rapidfuzz)
 
 install(EXPORT rapidfuzzTargets
-        FILE rapidfuzzTargets.cmake
         NAMESPACE rapidfuzz::
-        DESTINATION lib/cmake/rapidfuzz
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rapidfuzz
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8)
 
 project(rapidfuzz CXX)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(HEADERS
 	rapidfuzz/details/type_traits.hpp
 	rapidfuzz/details/types.hpp
 	rapidfuzz/details/unicode.hpp
+	rapidfuzz/details/matching_blocks.hpp
+	rapidfuzz/details/string_view.hpp
+	rapidfuzz/details/optional.hpp
 )
 
 add_library(rapidfuzz INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,25 +23,24 @@ set(HEADERS
 	src/details/unicode.hpp
 )
 
-add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+add_library(rapidfuzz SHARED ${SOURCES} ${HEADERS})
+set_target_properties(rapidfuzz PROPERTIES LINKER_LANGUAGE CXX)
 
 option(BUILD_TESTS "Build unit tests" OFF)
 if(BUILD_TESTS)
   add_subdirectory(test)
 endif()
 
-install(TARGETS ${CMAKE_PROJECT_NAME} 
-	EXPORT ${CMAKE_PROJECT_NAME}Targets
+install(TARGETS rapidfuzz
+	EXPORT rapidfuzzTargets
 	DESTINATION lib
 )
 
 install(FILES ${HEADERS} 
 	DESTINATION include/rapidfuzz)
 
-install(EXPORT ${CMAKE_PROJECT_NAME}Targets
-        FILE ${CMAKE_PROJECT_NAME}Targets.cmake
-        NAMESPACE ${CMAKE_PROJECT_NAME}::
-        DESTINATION lib/cmake/${CMAKE_PROJECT_NAME}
-         )
-# export(TARGETS ${CMAKE_PROJECT_NAME} FILE ${CMAKE_PROJECT_NAME}Targets.cmake)
+install(EXPORT rapidfuzzTargets
+        FILE rapidfuzzTargets.cmake
+        NAMESPACE rapidfuzz::
+        DESTINATION lib/cmake/rapidfuzz
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(rapidfuzz INTERFACE)
 add_library(rapidfuzz::rapidfuzz ALIAS rapidfuzz)
 
 set_target_properties(rapidfuzz PROPERTIES PUBLIC_HEADER "${HEADERS}")
+target_compile_features(rapidfuzz INTERFACE cxx_std_11)
 
 target_include_directories(rapidfuzz INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
                                                "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,23 +8,21 @@ option(BUILD_STATIC "Build static library" ON)
 option(BUILD_SHARED "Build shared library" ON)
 
 set(SOURCES
-	src/fuzz.txx
-	src/levenshtein.txx
-	src/process.txx
-	src/utils.txx
-	src/details/SentenceView.txx
+	rapidfuzz/fuzz.txx
+	rapidfuzz/levenshtein.txx
+	rapidfuzz/process.txx
+	rapidfuzz/utils.txx
 )
 
 set(HEADERS
-	src/fuzz.hpp
-	src/levenshtein.hpp
-	src/process.hpp
-	src/utils.hpp
-	src/details/SentenceView.hpp
-	src/details/SplittedSentenceView.hpp
-	src/details/type_traits.hpp
-	src/details/types.hpp
-	src/details/unicode.hpp
+	rapidfuzz/fuzz.hpp
+	rapidfuzz/levenshtein.hpp
+	rapidfuzz/process.hpp
+	rapidfuzz/utils.hpp
+	rapidfuzz/details/SplittedSentenceView.hpp
+	rapidfuzz/details/type_traits.hpp
+	rapidfuzz/details/types.hpp
+	rapidfuzz/details/unicode.hpp
 )
 
 function(set_rapidfuzz_properties TARGET)
@@ -32,11 +30,11 @@ function(set_rapidfuzz_properties TARGET)
 add_library(rapidfuzz::${TARGET} ALIAS ${TARGET})
 
 set_target_properties(${TARGET} PROPERTIES VERSION 0.0.0
-                                PUBLIC_HEADER ${HEADERS}
+                                PUBLIC_HEADER "${HEADERS}"
                                 LINKER_LANGUAGE CXX
                                 CXX_STANDARD 17)
 
-target_include_directories(${TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+target_include_directories(${TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
                                             "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>"
                                             "${CMAKE_CURRENT_LIST_DIR}/extern")
 install(TARGETS ${TARGET}
@@ -44,7 +42,7 @@ install(TARGETS ${TARGET}
         LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shlib
         ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT lib
         RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT bin
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}" COMPONENT dev
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapidfuzz" COMPONENT dev
 )
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(rapidfuzz CXX)
 include(GNUInstallDirs)
 
 option(BUILD_TESTS "Build unit tests" OFF)
-option(BUILD_STATIC "Build static library" ON)
-option(BUILD_SHARED "Build shared library" ON)
 
 set(SOURCES
 	rapidfuzz/fuzz.txx
@@ -25,36 +23,20 @@ set(HEADERS
 	rapidfuzz/details/unicode.hpp
 )
 
-function(set_rapidfuzz_properties TARGET)
+add_library(rapidfuzz INTERFACE)
+
 # provide a namespaced alias for clients to 'link' against if RapidFuzz is included as a sub-project
-add_library(rapidfuzz::${TARGET} ALIAS ${TARGET})
+add_library(rapidfuzz::rapidfuzz ALIAS rapidfuzz)
 
-set_target_properties(${TARGET} PROPERTIES VERSION 0.0.0
-                                PUBLIC_HEADER "${HEADERS}"
-                                LINKER_LANGUAGE CXX
-                                CXX_STANDARD 17)
+set_target_properties(rapidfuzz PROPERTIES PUBLIC_HEADER "${HEADERS}")
 
-target_include_directories(${TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-                                            "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>"
-                                            "${CMAKE_CURRENT_LIST_DIR}/extern")
-install(TARGETS ${TARGET}
-        EXPORT  ${TARGET}
-        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shlib
-        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT lib
-        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT bin
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapidfuzz" COMPONENT dev
+target_include_directories(rapidfuzz INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+                                               "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+install(TARGETS rapidfuzz
+        EXPORT  rapidfuzz
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapidfuzz"
 )
-endfunction()
-
-if(BUILD_SHARED)
-  add_library(rapidfuzz SHARED ${SOURCES} ${HEADERS})
-  set_rapidfuzz_properties(rapidfuzz)
-endif()
-
-if(BUILD_STATIC)
-  add_library(rapidfuzz-static OBJECT ${SOURCES} ${HEADERS})
-  set_rapidfuzz_properties(rapidfuzz-static)
-endif()
 
 if(BUILD_TESTS)
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+project(rapidfuzz CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+set(SOURCES
+	src/fuzz.txx
+	src/levenshtein.txx
+	src/process.txx
+	src/utils.txx
+	src/details/SentenceView.txx
+)
+
+set(HEADERS
+	src/fuzz.hpp
+	src/levenshtein.hpp
+	src/process.hpp
+	src/utils.hpp
+	src/details/SentenceView.hpp
+	src/details/SplittedSentenceView.hpp
+	src/details/type_traits.hpp
+	src/details/types.hpp
+	src/details/unicode.hpp
+)
+
+add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,5 +31,17 @@ if(BUILD_TESTS)
   add_subdirectory(test)
 endif()
 
-install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION lib)
-install(FILES ${HEADERS} DESTINATION include/rapidfuzz)
+install(TARGETS ${CMAKE_PROJECT_NAME} 
+	EXPORT ${CMAKE_PROJECT_NAME}Targets
+	DESTINATION lib
+)
+
+install(FILES ${HEADERS} 
+	DESTINATION include/rapidfuzz)
+
+install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+        FILE ${CMAKE_PROJECT_NAME}Targets.cmake
+        NAMESPACE ${CMAKE_PROJECT_NAME}::
+        DESTINATION lib/cmake/${CMAKE_PROJECT_NAME}
+         )
+# export(TARGETS ${CMAKE_PROJECT_NAME} FILE ${CMAKE_PROJECT_NAME}Targets.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(rapidfuzz CXX)
-set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 
 set(SOURCES
@@ -32,19 +31,20 @@ if(BUILD_TESTS)
   add_subdirectory(test)
 endif()
 
-install(TARGETS rapidfuzz
-	EXPORT rapidfuzzTargets
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-install(FILES ${HEADERS} 
-	DESTINATION include/rapidfuzz)
-
-install(EXPORT rapidfuzzTargets
-	    FILE rapidfuzzConfig.cmake
-        NAMESPACE rapidfuzz::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rapidfuzz
-)
-
 # provide a namespaced alias for clients to 'link' against if RapidFuzz is included as a sub-project
 add_library(rapidfuzz::rapidfuzz ALIAS rapidfuzz)
+
+set_target_properties(rapidfuzz PROPERTIES VERSION 0.0.0
+                                PUBLIC_HEADER ${HEADERS}
+                                CXX_STANDARD 17)
+
+target_include_directories(rapidfuzz PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+                                            "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>"
+                                            "${CMAKE_CURRENT_LIST_DIR}/extern")
+install(TARGETS rapidfuzz
+        EXPORT  rapidfuzz
+        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shlib
+        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT lib
+        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT bin
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}" COMPONENT dev
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8)
 
 project(rapidfuzz CXX)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(BUILD_SHARED)
 endif()
 
 if(BUILD_STATIC)
-  add_library(rapidfuzz-static ${SOURCES} ${HEADERS})
+  add_library(rapidfuzz-static OBJECT ${SOURCES} ${HEADERS})
   set_rapidfuzz_properties(rapidfuzz-static)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,6 @@ add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 
 add_subdirectory(test)
+
+install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include/rapidfuzz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(rapidfuzz CXX)
 include(GNUInstallDirs)
 
+option(BUILD_TESTS "Build unit tests" OFF)
+option(BUILD_STATIC "Build static library" ON)
+option(BUILD_SHARED "Build shared library" ON)
+
 set(SOURCES
 	src/fuzz.txx
 	src/levenshtein.txx
@@ -23,28 +27,37 @@ set(HEADERS
 	src/details/unicode.hpp
 )
 
-add_library(rapidfuzz SHARED ${SOURCES} ${HEADERS})
-set_target_properties(rapidfuzz PROPERTIES LINKER_LANGUAGE CXX)
-
-option(BUILD_TESTS "Build unit tests" OFF)
-if(BUILD_TESTS)
-  add_subdirectory(test)
-endif()
-
+function(set_rapidfuzz_properties TARGET)
 # provide a namespaced alias for clients to 'link' against if RapidFuzz is included as a sub-project
-add_library(rapidfuzz::rapidfuzz ALIAS rapidfuzz)
+add_library(rapidfuzz::${TARGET} ALIAS ${TARGET})
 
-set_target_properties(rapidfuzz PROPERTIES VERSION 0.0.0
+set_target_properties(${TARGET} PROPERTIES VERSION 0.0.0
                                 PUBLIC_HEADER ${HEADERS}
+                                LINKER_LANGUAGE CXX
                                 CXX_STANDARD 17)
 
-target_include_directories(rapidfuzz PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+target_include_directories(${TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
                                             "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>"
                                             "${CMAKE_CURRENT_LIST_DIR}/extern")
-install(TARGETS rapidfuzz
-        EXPORT  rapidfuzz
+install(TARGETS ${TARGET}
+        EXPORT  ${TARGET}
         LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shlib
         ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT lib
         RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT bin
         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}" COMPONENT dev
 )
+endfunction()
+
+if(BUILD_SHARED)
+  add_library(rapidfuzz SHARED ${SOURCES} ${HEADERS})
+  set_rapidfuzz_properties(rapidfuzz)
+endif()
+
+if(BUILD_STATIC)
+  add_library(rapidfuzz-static ${SOURCES} ${HEADERS})
+  set_rapidfuzz_properties(rapidfuzz-static)
+endif()
+
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rapidfuzz CXX)
 include(GNUInstallDirs)
 
 option(BUILD_TESTS "Build unit tests" OFF)
+option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 
 set(SOURCES
 	rapidfuzz/fuzz.txx
@@ -43,4 +44,8 @@ install(TARGETS rapidfuzz
 
 if(BUILD_TESTS)
   add_subdirectory(test)
+endif()
+
+if(BUILD_BENCHMARKS)
+  add_subdirectory(bench)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ install(FILES ${HEADERS}
 	DESTINATION include/rapidfuzz)
 
 install(EXPORT rapidfuzzTargets
+	    FILE rapidfuzzConfig.cmake
         NAMESPACE rapidfuzz::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rapidfuzz
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,3 +45,6 @@ install(EXPORT rapidfuzzTargets
         NAMESPACE rapidfuzz::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rapidfuzz
 )
+
+# provide a namespaced alias for clients to 'link' against if RapidFuzz is included as a sub-project
+add_library(rapidfuzz::rapidfuzz ALIAS rapidfuzz)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,46 @@ The Library is splitted across multiple repositories for the different supported
 - The Python version can be found at [maxbachmann/rapidfuzz](https://github.com/maxbachmann/rapidfuzz)
 
 
-## Installation
-As of now it it only possible to use the sources directly by adding them to your project. There will be a version on conan in the future.
+## Compilation
+
+RadidFuzz now support CMake.
+To build it you can do :
+
+    git clone https://github.com/maxbachmann/rapidfuzz-cpp.git rapidfuzz-cpp
+    cd rapidfuzz-cpp
+    mkdir build && cd build
+    cmake ..
+    cmake --build .
+    cmake --build . --target install
+
+RapidFuzz exports its targets to CMake. 
+You can easily integrate it in your CMake project with 3 options.
+
+1. include it as a subdirectory:
+Clone this repo (or make a copy) into your project source tree, lets say in `3rdparty/RapidFuzz`folder.
+Then, in your `CMakeLists.txt` use :
+
+    add_subdirectory(rapidfuzz-cpp)
+    add_executable(foo main.cpp)
+    target_link_libraries(foo rapidfuzz::rapidfuzz)  
+
+2. build it at configure time with FetchContent:
+    
+    FetchContent_Declare( 
+      rapidfuzz
+        SOURCE_DIR ${CMAKE_SOURCE_DIR}/3rdparty/rapidfuzz-cpp
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/rapidfuzz
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> "${CMAKE_OPT_ARGS}"
+    )
+    FetchContent_MakeAvailable(rapidfuzz)
+    add_executable(foo main.cpp)
+    target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
+
+3. use find_package(rapifuzz) if you install it already
+
+    find_package(rapidfuzz REQUIRED)
+    add_executable(foo main.cpp)
+    target_link_libraries(foo rapidfuzz::rapidfuzz)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -45,34 +45,36 @@ The Library is splitted across multiple repositories for the different supported
 There are severals ways to integrate `rapidfuzz` in your CMake project.
 
 ### By Installing it
+```bash
+git clone https://github.com/maxbachmann/rapidfuzz-cpp.git rapidfuzz-cpp
+cd rapidfuzz-cpp
+mkdir build && cd build
+cmake ..
+cmake --build .
+cmake --build . --target install
+```
 
-    git clone https://github.com/maxbachmann/rapidfuzz-cpp.git rapidfuzz-cpp
-    cd rapidfuzz-cpp
-    mkdir build && cd build
-    cmake ..
-    cmake --build .
-    cmake --build . --target install
-
-Then in your CMakeLists.txt : 
-
-    find_package(rapidfuzz REQUIRED)
-    add_executable(foo main.cpp)
-    target_link_libraries(foo rapidfuzz::rapidfuzz)
+Then in your CMakeLists.txt: 
+```cmake
+find_package(rapidfuzz REQUIRED)
+add_executable(foo main.cpp)
+target_link_libraries(foo rapidfuzz::rapidfuzz)
+```
 
 ### Add this repository as a submodule
-
-    git submodule add https://github.com/maxbachmann/rapidfuzz-cpp.git 3rdparty/RapidFuzz
-
+```bash
+git submodule add https://github.com/maxbachmann/rapidfuzz-cpp.git 3rdparty/RapidFuzz
+```
 Then you can either:
 
 1. include it as a subdirectory
-
+    ```cmake
     add_subdirectory(3rdparty/RapidFuzz)
     add_executable(foo main.cpp)
-    target_link_libraries(foo rapidfuzz::rapidfuzz)  
-
+    target_link_libraries(foo rapidfuzz::rapidfuzz)
+    ```
 2. build it at configure time with `FetchContent`
-    
+    ```cmake
     FetchContent_Declare( 
       rapidfuzz
       SOURCE_DIR ${CMAKE_SOURCE_DIR}/3rdparty/RapidFuzz
@@ -82,25 +84,27 @@ Then you can either:
     FetchContent_MakeAvailable(rapidfuzz)
     add_executable(foo main.cpp)
     target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
-
+    ```
 ### Download it at configure time
 
 If you don't want to add `rapidfuzz-cpp` as a submodule, you can also download it with `FetchContent`:
-
-    FetchContent_Declare(rapidfuzz
-      GIT_REPOSITORY https://github.com/maxbachmann/rapidfuzz-cpp.git
-      GIT_TAG master)
-    FetchContent_MakeAvailable(rapidfuzz)
-    add_executable(foo main.cpp)
-    target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
-
+```cmake
+FetchContent_Declare(rapidfuzz
+  GIT_REPOSITORY https://github.com/maxbachmann/rapidfuzz-cpp.git
+  GIT_TAG master)
+FetchContent_MakeAvailable(rapidfuzz)
+add_executable(foo main.cpp)
+target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
+```
 It will be downloaded each time you run CMake in a blank folder.   
 
 ## CMake option 
 
-There are CMake options available :
-`BUILD_TESTS` : to build test (default OFF)
-`BUILD_BENCHMARKS` : to build benchmarks (default OFF and requires Google Benchmark)
+There are CMake options available:
+
+`BUILD_TESTS` : to build test (default OFF and requires [Catch2](https://github.com/catchorg/Catch2))
+
+`BUILD_BENCHMARKS` : to build benchmarks (default OFF and requires [Google Benchmark](https://github.com/google/benchmark))
 
 ## Usage
 ```cpp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">
+  <h1 align="center">
 <img src="https://raw.githubusercontent.com/maxbachmann/rapidfuzz/master/docs/img/RapidFuzz.svg?sanitize=true" alt="RapidFuzz" width="400">
 </h1>
 <h4 align="center">Rapid fuzzy string matching in C++ using the Levenshtein Distance</h4>
@@ -81,6 +81,12 @@ Then, in your `CMakeLists.txt` use :
     add_executable(foo main.cpp)
     target_link_libraries(foo rapidfuzz::rapidfuzz)
 
+## CMake option 
+
+There are 3 CMake options available :
+`BUILD_TESTS` : to build test (default OFF)
+`BUILD_STATIC` : to build a static library (default ON)
+`BUILD_SHARED` : to build a shared library (default ON), which produce the target `rapidfuzz::rapidfuzz-static`
 
 ## Usage
 ```cpp

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Then, in your `CMakeLists.txt` use :
     add_executable(foo main.cpp)
     target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
 
-3. use find_package(rapifuzz) if you install it already
+3. use find_package(rapidfuzz) if you already have it installed
 
     find_package(rapidfuzz REQUIRED)
     add_executable(foo main.cpp)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Library is splitted across multiple repositories for the different supported
 
 ## Compilation
 
-RadidFuzz now support CMake.
+RapidFuzz now supports CMake.
 To build it you can do :
 
     git clone https://github.com/maxbachmann/rapidfuzz-cpp.git rapidfuzz-cpp

--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ Then, in your `CMakeLists.txt` use :
 
 ## CMake option 
 
-There are 3 CMake options available :
+There are CMake options available :
 `BUILD_TESTS` : to build test (default OFF)
-`BUILD_STATIC` : to build a static library (default ON)
-`BUILD_SHARED` : to build a shared library (default ON), which produce the target `rapidfuzz::rapidfuzz-static`
+`BUILD_BENCHMARKS` : to build benchmarks (default OFF and requires Google Benchmark)
 
 ## Usage
 ```cpp

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ The Library is splitted across multiple repositories for the different supported
 - The Python version can be found at [maxbachmann/rapidfuzz](https://github.com/maxbachmann/rapidfuzz)
 
 
-## Compilation
+## CMake Integration
 
-RapidFuzz now supports CMake.
-To build it you can do :
+There are severals ways to integrate `rapidfuzz` in your CMake project.
+
+### By Installing it
 
     git clone https://github.com/maxbachmann/rapidfuzz-cpp.git rapidfuzz-cpp
     cd rapidfuzz-cpp
@@ -52,34 +53,48 @@ To build it you can do :
     cmake --build .
     cmake --build . --target install
 
-RapidFuzz exports its targets to CMake. 
-You can easily integrate it in your CMake project with 3 options.
+Then in your CMakeLists.txt : 
 
-1. include it as a subdirectory:
-Clone this repo (or make a copy) into your project source tree, lets say in `3rdparty/RapidFuzz`folder.
-Then, in your `CMakeLists.txt` use :
+    find_package(rapidfuzz REQUIRED)
+    add_executable(foo main.cpp)
+    target_link_libraries(foo rapidfuzz::rapidfuzz)
 
-    add_subdirectory(rapidfuzz-cpp)
+### Add this repository as a submodule
+
+    git submodule add https://github.com/maxbachmann/rapidfuzz-cpp.git 3rdparty/RapidFuzz
+
+Then you can either:
+
+1. include it as a subdirectory
+
+    add_subdirectory(3rdparty/RapidFuzz)
     add_executable(foo main.cpp)
     target_link_libraries(foo rapidfuzz::rapidfuzz)  
 
-2. build it at configure time with FetchContent:
+2. build it at configure time with `FetchContent`
     
     FetchContent_Declare( 
       rapidfuzz
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/3rdparty/rapidfuzz-cpp
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/rapidfuzz
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> "${CMAKE_OPT_ARGS}"
+      SOURCE_DIR ${CMAKE_SOURCE_DIR}/3rdparty/RapidFuzz
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/rapidfuzz
+      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> "${CMAKE_OPT_ARGS}"
     )
     FetchContent_MakeAvailable(rapidfuzz)
     add_executable(foo main.cpp)
     target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
 
-3. use find_package(rapidfuzz) if you already have it installed
+### Download it at configure time
 
-    find_package(rapidfuzz REQUIRED)
+If you don't want to add `rapidfuzz-cpp` as a submodule, you can also download it with `FetchContent`:
+
+    FetchContent_Declare(rapidfuzz
+      GIT_REPOSITORY https://github.com/maxbachmann/rapidfuzz-cpp.git
+      GIT_TAG master)
+    FetchContent_MakeAvailable(rapidfuzz)
     add_executable(foo main.cpp)
-    target_link_libraries(foo rapidfuzz::rapidfuzz)
+    target_link_libraries(foo PRIVATE rapidfuzz::rapidfuzz)
+
+It will be downloaded each time you run CMake in a blank folder.   
 
 ## CMake option 
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(benchmark REQUIRED)
+
+function(rapidfuzz_add_benchmark NAME SOURCE)
+	add_executable(bench_${NAME} ${SOURCE})
+	target_link_libraries(bench_${NAME} ${PROJECT_NAME})
+	target_link_libraries(bench_${NAME} benchmark::benchmark)
+endfunction()  
+
+rapidfuzz_add_benchmark(fuzz bench-fuzz.cpp)
+rapidfuzz_add_benchmark(levenshtein bench-levenshtein.cpp)
+rapidfuzz_add_benchmark(process bench-process.cpp)

--- a/bench/bench-fuzz.cpp
+++ b/bench/bench-fuzz.cpp
@@ -1,5 +1,5 @@
 #include <benchmark/benchmark.h>
-#include "../src/fuzz.hpp"
+#include <rapidfuzz/fuzz.hpp>
 #include <string>
 #include <vector>
 

--- a/bench/bench-levenshtein.cpp
+++ b/bench/bench-levenshtein.cpp
@@ -1,6 +1,6 @@
 #include <benchmark/benchmark.h>
-#include "../rapidfuzz/levenshtein.hpp"
-#include "../rapidfuzz/details/string_view.hpp"
+#include <rapidfuzz/levenshtein.hpp>
+#include <rapidfuzz/details/string_view.hpp>
 #include <string>
 #include <vector>
 

--- a/bench/bench-process.cpp
+++ b/bench/bench-process.cpp
@@ -1,8 +1,9 @@
 #include <benchmark/benchmark.h>
-#include "../src/process.hpp"
+#include <rapidfuzz/process.hpp>
 #include <string>
 #include <vector>
 
+using namespace rapidfuzz;
 static void BM_ProcessExtract1(benchmark::State &state) {
   std::wstring a = L"aaaaa";
   std::vector<std::wstring> b(1000, L"aaaaa");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+find_package(Boost REQUIRED)
+find_package(Catch2 REQUIRED)
+
+add_executable(fuzzy_tests tests-main.cpp tests-levenshtein.cpp)
+target_link_libraries(fuzzy_tests ${PROJECT_NAME})
+target_link_libraries(fuzzy_tests Catch2::Catch2)
+target_include_directories(fuzzy_tests PUBLIC ${CMAKE_SOURCE_DIR}/extern/)
+target_include_directories(fuzzy_tests  PRIVATE ${Boost_INCLUDE_DIRS})
+add_test(NAME tests COMMAND fuzzy_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(Boost REQUIRED)
 find_package(Catch2 REQUIRED)
 
 add_executable(fuzzy_tests tests-main.cpp tests-levenshtein.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,14 @@
 find_package(Catch2 REQUIRED)
 
-add_executable(fuzzy_tests tests-main.cpp tests-levenshtein.cpp)
-target_link_libraries(fuzzy_tests ${PROJECT_NAME})
-target_link_libraries(fuzzy_tests Catch2::Catch2)
-target_include_directories(fuzzy_tests PUBLIC ${CMAKE_SOURCE_DIR}/extern/)
-target_include_directories(fuzzy_tests  PRIVATE ${Boost_INCLUDE_DIRS})
-add_test(NAME tests COMMAND fuzzy_tests)
+enable_testing()
+
+function(rapidfuzz_add_test NAME SOURCE)
+	add_executable(test_${NAME} tests-main.cpp ${SOURCE})
+	target_link_libraries(test_${NAME} ${PROJECT_NAME})
+	target_link_libraries(test_${NAME} Catch2::Catch2)
+	add_test(NAME ${NAME} COMMAND test_${NAME})
+endfunction()  
+
+rapidfuzz_add_test(fuzz tests-fuzz.cpp)
+rapidfuzz_add_test(levenshtein tests-levenshtein.cpp)
+rapidfuzz_add_test(utils tests-utils.cpp)

--- a/test/tests-fuzz.cpp
+++ b/test/tests-fuzz.cpp
@@ -1,7 +1,7 @@
-#include "../rapidfuzz/utils.hpp"
-#include "../rapidfuzz/fuzz.hpp"
+#include <rapidfuzz/utils.hpp>
+#include <rapidfuzz/fuzz.hpp>
 
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 namespace fuzz = rapidfuzz::fuzz;
 namespace utils = rapidfuzz::utils;

--- a/test/tests-levenshtein.cpp
+++ b/test/tests-levenshtein.cpp
@@ -1,4 +1,4 @@
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 #include <algorithm>
 #include <boost/utility/string_view.hpp>
 #include <string_view>

--- a/test/tests-levenshtein.cpp
+++ b/test/tests-levenshtein.cpp
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <vector>
 
-#include "../src/levenshtein.hpp"
+#include <rapidfuzz/levenshtein.hpp>
 
 namespace levenshtein = rapidfuzz::levenshtein;
 

--- a/test/tests-utils.cpp
+++ b/test/tests-utils.cpp
@@ -1,11 +1,11 @@
-#include "../rapidfuzz/utils.hpp"
-#include "../rapidfuzz/fuzz.hpp"
-#include "../rapidfuzz/details/string_view.hpp"
+#include <rapidfuzz/utils.hpp>
+#include <rapidfuzz/fuzz.hpp>
+#include <rapidfuzz/details/string_view.hpp>
 
 #include <string>
 #include <vector>
 
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>
 
 namespace utils = rapidfuzz::utils;
 


### PR DESCRIPTION
This PR adds some CMakeLists.txt to configure and build `rapidfuzz-cpp`.
It also export the lib to make it easy to integrate into other CMake project.
I made a sample project that demonstrate how to integrate it : https://github.com/avilleret/rapidfuzz-test

3 options are available : 
BUILD_TESTS : to build test
BUILD_STATIC : to build static library (in fact its an object only library, no archive)
BUILD_SHARED : to build shared library

Feedback are welcome :-)