### PR TITLE
fix size_t casts for MSVC

### DIFF
--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -140,7 +140,7 @@ struct PatternMatchVector {
     : m_key(), m_val()
   {
     for (std::size_t i = 0; i < s.size(); i++){
-      insert(s[i], i);
+      insert(s[i], static_cast<int>(i));
     }
   }
 
@@ -187,7 +187,7 @@ struct PatternMatchVector<1> {
     : m_val()
   {
     for (std::size_t i = 0; i < s.size(); i++){
-      insert(s[i], i);
+      insert(s[i], static_cast<int>(i));
     }
   }
 
@@ -231,7 +231,7 @@ struct BlockPatternMatchVector {
 
     for (std::size_t i = 0; i < s.size(); i++){
       auto* be = &m_val[i/64];
-      be->insert(s[i], i%64);
+      be->insert(s[i], static_cast<int>(i%64));
     }
   }
 

--- a/rapidfuzz/details/string_metrics/weighted_levenshtein_impl.hpp
+++ b/rapidfuzz/details/string_metrics/weighted_levenshtein_impl.hpp
@@ -150,7 +150,7 @@ static inline std::size_t weighted_levenshtein_bitpal(basic_string_view<CharT1> 
   }
 
   std::size_t dist = s1.size() + s2_len;
-  uint64_t bitmask = set_bits(s2_len);
+  uint64_t bitmask = set_bits(static_cast<int>(s2_len));
 
   dist -= popcount64(DHzero & bitmask);
   dist -= popcount64(DHpos1 & bitmask) * 2;
@@ -371,7 +371,7 @@ std::size_t weighted_levenshtein_bitpal_blockwise(basic_string_view<CharT1> s1,
     dist -= popcount64(DH[word].DHpos1) * 2;
   }
 
-  uint64_t bitmask = set_bits(s2_len - (words - 1) * 64);
+  uint64_t bitmask = set_bits(static_cast<int>(s2_len - (words - 1) * 64));
   dist -= popcount64(DH.back().DHzero & bitmask);
   dist -= popcount64(DH.back().DHpos1 & bitmask) * 2;
 


### PR DESCRIPTION
under MSVC there are warnings about implicit casts from size_t to int, added explicit static_cast for conversions where I have found these issues.