### PR TITLE
Minor fixes to allow building with -Werror=shadow

### DIFF
--- a/extras/rapidfuzz_amalgamated.hpp
+++ b/extras/rapidfuzz_amalgamated.hpp
@@ -4426,8 +4426,8 @@ struct MatchingBlock {
   std::size_t spos;
   std::size_t dpos;
   std::size_t length;	
-  MatchingBlock(std::size_t spos, std::size_t dpos, std::size_t length)
-      : spos(spos), dpos(dpos), length(length)
+  MatchingBlock(std::size_t aSPos, std::size_t aDPos, std::size_t aLength)
+      : spos(aSPos), dpos(aDPos), length(aLength)
   {}
 };
 

--- a/rapidfuzz/details/matching_blocks.hpp
+++ b/rapidfuzz/details/matching_blocks.hpp
@@ -36,9 +36,9 @@ namespace detail {
 struct MatchingBlock {
   std::size_t spos;
   std::size_t dpos;
-  std::size_t length;	
-  MatchingBlock(std::size_t spos, std::size_t dpos, std::size_t length)
-      : spos(spos), dpos(dpos), length(length)
+  std::size_t length;
+  MatchingBlock(std::size_t aSPos, std::size_t aDPos, std::size_t aLength)
+      : spos(aSPos), dpos(aDPos), length(aLength)
   {}
 };
 

--- a/rapidfuzz/string_metric.hpp
+++ b/rapidfuzz/string_metric.hpp
@@ -192,8 +192,8 @@ template<typename Sentence1>
 struct CachedLevenshtein {
   using CharT1 = char_type<Sentence1>;
 
-  CachedLevenshtein(const Sentence1& s1, LevenshteinWeightTable weights = {1, 1, 1})
-    : s1_view(common::to_string_view(s1)), blockmap_s1(s1_view), weights(weights) {}
+  CachedLevenshtein(const Sentence1& s1, LevenshteinWeightTable aWeights = {1, 1, 1})
+    : s1_view(common::to_string_view(s1)), blockmap_s1(s1_view), weights(aWeights) {}
 
   template<typename Sentence2>
   std::size_t distance(const Sentence2& s2, std::size_t max = std::numeric_limits<std::size_t>::max()) const
@@ -334,8 +334,8 @@ template<typename Sentence1>
 struct CachedNormalizedLevenshtein {
   using CharT1 = char_type<Sentence1>;
 
-  CachedNormalizedLevenshtein(const Sentence1& s1, LevenshteinWeightTable weights = {1, 1, 1})
-    : s1_view(common::to_string_view(s1)), blockmap_s1(s1_view), weights(weights) {}
+  CachedNormalizedLevenshtein(const Sentence1& s1, LevenshteinWeightTable aWeights = {1, 1, 1})
+    : s1_view(common::to_string_view(s1)), blockmap_s1(s1_view), weights(aWeights) {}
 
   template<typename Sentence2>
   double ratio(const Sentence2& s2, percent score_cutoff = 0) const


### PR DESCRIPTION
The current code uses the same variable name in arguments and as a member in a few places. This can be slightly misleading and can sometimes cause trouble in refactoring. Its certainly not a big issue but may be nice to fix?

This PR adds a minor change in oder to be able to build with slightly more pedantic build settings that forbid shadowed variable names (`-Werror=shadow` for clang).