### PR TITLE
Fix levenshtein_editops_impl assert comp error.

### DIFF
--- a/rapidfuzz/details/string_metrics/levenshtein_editops_impl.hpp
+++ b/rapidfuzz/details/string_metrics/levenshtein_editops_impl.hpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* Copyright © 2021 Max Bachmann */
 
+#include <cassert>
 #include <algorithm>
 #include <array>
 #include <limits>


### PR DESCRIPTION
Found minor error during cmake compilation (#45). 

Fixed by adding appropriate `<cassert>` header to remove compiler confusion.