### PR TITLE
Fix MSVC warnings

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,14 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: install Catch2
-      run: |
-          git clone https://github.com/catchorg/Catch2.git
-          cd Catch2
-          git checkout v3.0.0-preview3
-          cmake -Bbuild -H. -DBUILD_TESTING=OFF
-          sudo cmake --build build/ --target install
-
     - name: Configure CMake
       run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DRAPIDFUZZ_BUILD_TESTING=1 -DRAPIDFUZZ_BUILD_FUZZERS=1 -DCMAKE_CXX_COMPILER=clang++
 

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -270,8 +270,8 @@ struct BlockPatternMatchVector {
     template <typename InputIt>
     void insert(InputIt first, InputIt last)
     {
-        int64_t len = std::distance(first, last);
-        auto block_count = static_cast<std::ptrdiff_t>((len / 64) + bool(len % 64));
+        auto len = std::distance(first, last);
+        auto block_count = len / 64 + bool(len % 64);
         m_val.resize(block_count);
 
         for (std::ptrdiff_t block = 0; block < block_count; ++block) {

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -348,10 +348,13 @@ struct CharSet {
 
 template <typename T>
 struct MatrixVectorView {
+
+    using value_type = T;
+
     MatrixVectorView(T* vector, std::size_t cols) noexcept : m_vector(vector), m_cols(cols)
     {}
 
-    T& operator[](std::size_t col) noexcept
+    value_type& operator[](std::size_t col) noexcept
     {
         assert(col < m_cols);
         return m_vector[col];
@@ -369,6 +372,9 @@ private:
 
 template <typename T>
 struct ConstMatrixVectorView {
+
+    using value_type = T;
+
     ConstMatrixVectorView(const T* vector, std::size_t cols) noexcept
         : m_vector(vector), m_cols(cols)
     {}
@@ -376,7 +382,7 @@ struct ConstMatrixVectorView {
     ConstMatrixVectorView(const MatrixVectorView<T>& other) noexcept : m_vector(other.m_vector)
     {}
 
-    const T& operator[](std::size_t col) const noexcept
+    const value_type& operator[](std::size_t col) const noexcept
     {
         assert(col < m_cols);
         return m_vector[col];
@@ -415,16 +421,16 @@ struct Matrix {
         delete[] m_matrix;
     }
 
-    MatrixVectorView<uint64_t> operator[](std::size_t row) noexcept
+    MatrixVectorView<value_type> operator[](std::size_t row) noexcept
     {
         assert(row < m_rows);
-        return MatrixVectorView<uint64_t>(&m_matrix[row * m_cols], m_cols);
+        return MatrixVectorView<value_type>(&m_matrix[row * m_cols], m_cols);
     }
 
-    ConstMatrixVectorView<uint64_t> operator[](std::size_t row) const noexcept
+    ConstMatrixVectorView<value_type> operator[](std::size_t row) const noexcept
     {
         assert(row < m_rows);
-        return ConstMatrixVectorView<uint64_t>(&m_matrix[row * m_cols], m_cols);
+        return ConstMatrixVectorView<value_type>(&m_matrix[row * m_cols], m_cols);
     }
 
     std::size_t rows() const noexcept

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -345,10 +345,10 @@ struct CharSet {
 
 template <typename T>
 struct MatrixVectorView {
-    explicit MatrixVectorView(T* vector, std::size_t cols) : m_vector(vector), m_cols(cols)
+    MatrixVectorView(T* vector, std::size_t cols) noexcept : m_vector(vector), m_cols(cols)
     {}
 
-    T& operator[](std::size_t col)
+    T& operator[](std::size_t col) noexcept
     {
         assert(col < m_cols);
         return m_vector[col];
@@ -366,13 +366,13 @@ private:
 
 template <typename T>
 struct ConstMatrixVectorView {
-    explicit ConstMatrixVectorView(const T* vector, std::size_t cols) : m_vector(vector), m_cols(cols)
+    ConstMatrixVectorView(const T* vector, std::size_t cols) noexcept : m_vector(vector), m_cols(cols)
     {}
 
-    ConstMatrixVectorView(const MatrixVectorView<T>& other) : m_vector(other.m_vector)
+    ConstMatrixVectorView(const MatrixVectorView<T>& other) noexcept : m_vector(other.m_vector)
     {}
 
-    const T& operator[](std::size_t col)
+    const T& operator[](std::size_t col) const noexcept
     {
         assert(col < m_cols);
         return m_vector[col];

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -48,8 +48,10 @@ constexpr double result_cutoff(double result, double score_cutoff)
 template <int Max = 1>
 constexpr double norm_distance(int64_t dist, int64_t lensum, double score_cutoff = 0)
 {
-    double max = static_cast<double>(Max);
-    return result_cutoff((lensum > 0) ? (max - max * dist / lensum) : max, score_cutoff);
+    auto max = static_cast<double>(Max);
+    return result_cutoff(
+        (lensum > 0) ? (max - max * static_cast<double>(dist) / static_cast<double>(lensum)) : max,
+        score_cutoff);
 }
 
 template <int Max = 1>
@@ -124,10 +126,12 @@ StringAffix remove_common_affix(InputIt1& first1, InputIt1& last1, InputIt2& fir
                                 InputIt2& last2);
 
 template <typename InputIt1, typename InputIt2>
-std::ptrdiff_t remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2, InputIt2 last2);
+std::ptrdiff_t remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
+                                    InputIt2 last2);
 
 template <typename InputIt1, typename InputIt2>
-std::ptrdiff_t remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2, InputIt2& last2);
+std::ptrdiff_t remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
+                                    InputIt2& last2);
 
 template <typename InputIt, typename CharT = iterator_type<InputIt>>
 SplittedSentenceView<InputIt> sorted_split(InputIt first, InputIt last);
@@ -195,10 +199,10 @@ struct PatternMatchVector {
     uint64_t get(CharT key) const
     {
         if (key >= 0 && key <= 255) {
-            return m_extendedAscii[(uint8_t)key];
+            return m_extendedAscii[static_cast<uint8_t>(key)];
         }
         else {
-            return m_map[lookup((uint64_t)key)].value;
+            return m_map[lookup(static_cast<uint64_t>(key))].value;
         }
     }
 
@@ -251,8 +255,7 @@ private:
 struct BlockPatternMatchVector {
     std::vector<PatternMatchVector> m_val;
 
-    BlockPatternMatchVector()
-    {}
+    BlockPatternMatchVector() = default;
 
     template <typename InputIt>
     BlockPatternMatchVector(InputIt first, InputIt last)
@@ -366,7 +369,8 @@ private:
 
 template <typename T>
 struct ConstMatrixVectorView {
-    ConstMatrixVectorView(const T* vector, std::size_t cols) noexcept : m_vector(vector), m_cols(cols)
+    ConstMatrixVectorView(const T* vector, std::size_t cols) noexcept
+        : m_vector(vector), m_cols(cols)
     {}
 
     ConstMatrixVectorView(const MatrixVectorView<T>& other) noexcept : m_vector(other.m_vector)
@@ -411,13 +415,13 @@ struct Matrix {
         delete[] m_matrix;
     }
 
-    MatrixVectorView<uint64_t> operator[](std::size_t row)
+    MatrixVectorView<uint64_t> operator[](std::size_t row) noexcept
     {
         assert(row < m_rows);
         return MatrixVectorView<uint64_t>(&m_matrix[row * m_cols], m_cols);
     }
 
-    ConstMatrixVectorView<uint64_t> operator[](std::size_t row) const
+    ConstMatrixVectorView<uint64_t> operator[](std::size_t row) const noexcept
     {
         assert(row < m_rows);
         return ConstMatrixVectorView<uint64_t>(&m_matrix[row * m_cols], m_cols);

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -238,7 +238,7 @@ private:
 
         uint64_t perturb = key;
         while (true) {
-            i = ((i * 5) + perturb + 1) % 128;
+            i = (static_cast<uint64_t>(i) * 5 + perturb + 1) % 128;
             if (!m_map[i].value || m_map[i].key == key) {
                 return i;
             }

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -48,7 +48,7 @@ constexpr double result_cutoff(double result, double score_cutoff)
 template <int Max = 1>
 constexpr double norm_distance(int64_t dist, int64_t lensum, double score_cutoff = 0)
 {
-    auto max = static_cast<double>(Max);
+    double max = static_cast<double>(Max);
     return result_cutoff(
         (lensum > 0) ? (max - max * static_cast<double>(dist) / static_cast<double>(lensum)) : max,
         score_cutoff);

--- a/rapidfuzz/details/common_impl.hpp
+++ b/rapidfuzz/details/common_impl.hpp
@@ -62,10 +62,10 @@ common::mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 fir
  * Removes common prefix of two string views
  */
 template <typename InputIt1, typename InputIt2>
-int64_t common::remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
+std::ptrdiff_t common::remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
                                      InputIt2 last2)
 {
-    int64_t prefix = std::distance(first1, common::mismatch(first1, last1, first2, last2).first);
+    auto prefix = std::distance(first1, common::mismatch(first1, last1, first2, last2).first);
     first1 += prefix;
     first2 += prefix;
     return prefix;
@@ -75,7 +75,7 @@ int64_t common::remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2&
  * Removes common suffix of two string views
  */
 template <typename InputIt1, typename InputIt2>
-int64_t common::remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
+std::ptrdiff_t common::remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
                                      InputIt2& last2)
 {
     auto rfirst1 = std::make_reverse_iterator(last1);
@@ -83,7 +83,7 @@ int64_t common::remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 
     auto rfirst2 = std::make_reverse_iterator(last2);
     auto rlast2 = std::make_reverse_iterator(first2);
 
-    int64_t suffix =
+    auto suffix =
         std::distance(rfirst1, common::mismatch(rfirst1, rlast1, rfirst2, rlast2).first);
     last1 -= suffix;
     last2 -= suffix;
@@ -97,8 +97,8 @@ template <typename InputIt1, typename InputIt2>
 StringAffix common::remove_common_affix(InputIt1& first1, InputIt1& last1, InputIt2& first2,
                                         InputIt2& last2)
 {
-    return StringAffix{(int64_t)remove_common_prefix(first1, last1, first2, last2),
-                       (int64_t)remove_common_suffix(first1, last1, first2, last2)};
+    return StringAffix{remove_common_prefix(first1, last1, first2, last2),
+                       remove_common_suffix(first1, last1, first2, last2)};
 }
 
 template <typename, typename = void>

--- a/rapidfuzz/details/matching_blocks.hpp
+++ b/rapidfuzz/details/matching_blocks.hpp
@@ -192,7 +192,7 @@ protected:
 private:
     // Cache to avoid reallocations
     std::vector<Index> j2len_;
-    std::unordered_map<typename std::iterator_traits<InputIt2>::value_type, std::vector<Index>> b2j_;
+    std::unordered_map<iterator_type<InputIt2>, std::vector<Index>> b2j_;
 };
 } // namespace difflib
 

--- a/rapidfuzz/details/matching_blocks.hpp
+++ b/rapidfuzz/details/matching_blocks.hpp
@@ -33,10 +33,10 @@
 namespace rapidfuzz {
 namespace detail {
 struct MatchingBlock {
-    int64_t spos;
-    int64_t dpos;
-    int64_t length;
-    MatchingBlock(int64_t aSPos, int64_t aDPos, int64_t aLength)
+    std::ptrdiff_t spos;
+    std::ptrdiff_t dpos;
+    std::ptrdiff_t length;
+    MatchingBlock(std::ptrdiff_t aSPos, std::ptrdiff_t aDPos, std::ptrdiff_t aLength)
         : spos(aSPos), dpos(aDPos), length(aLength)
     {}
 };
@@ -45,37 +45,38 @@ namespace difflib {
 
 template <typename InputIt1, typename InputIt2>
 class SequenceMatcher {
+    using Index = std::ptrdiff_t;
 public:
-    using match_t = std::tuple<int64_t, int64_t, int64_t>;
+    using match_t = std::tuple<Index, Index, Index>;
 
     SequenceMatcher(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
         : a_first(first1), a_last(last1), b_first(first2), b_last(last2)
     {
-        int64_t b_len = std::distance(b_first, b_last);
+        auto b_len = std::distance(b_first, b_last);
         j2len_.resize(b_len + 1);
-        for (int64_t i = 0; i < b_len; ++i) {
+        for (Index i = 0; i < b_len; ++i) {
             b2j_[b_first[i]].push_back(i);
         }
     }
 
-    match_t find_longest_match(int64_t a_low, int64_t a_high, int64_t b_low, int64_t b_high)
+    match_t find_longest_match(Index a_low, Index a_high, Index b_low, Index b_high)
     {
-        int64_t best_i = a_low;
-        int64_t best_j = b_low;
-        int64_t best_size = 0;
+        Index best_i = a_low;
+        Index best_j = b_low;
+        Index best_size = 0;
 
         // Find longest junk free match
         {
-            for (int64_t i = a_low; i < a_high; ++i) {
+            for (Index i = a_low; i < a_high; ++i) {
                 bool found = false;
                 auto iter = b2j_.find(a_first[i]);
                 if (iter != std::end(b2j_)) {
                     const auto& indexes = iter->second;
 
                     size_t pos = 0;
-                    int64_t next_val = 0;
+                    Index next_val = 0;
                     for (; pos < indexes.size(); pos++) {
-                        int64_t j = indexes[pos];
+                        Index j = indexes[pos];
                         if (j < b_low) continue;
 
                         next_val = j2len_[j];
@@ -83,11 +84,11 @@ public:
                     }
 
                     for (; pos < indexes.size(); pos++) {
-                        int64_t j = indexes[pos];
+                        Index j = indexes[pos];
                         if (j >= b_high) break;
 
                         found = true;
-                        int64_t k = next_val + 1;
+                        Index k = next_val + 1;
 
                         /* the next value might be overwritten below
                          * so cache it */
@@ -129,10 +130,10 @@ public:
 
     std::vector<MatchingBlock> get_matching_blocks()
     {
-        int64_t a_len = std::distance(a_first, a_last);
-        int64_t b_len = std::distance(b_first, b_last);
+        auto a_len = std::distance(a_first, a_last);
+        auto b_len = std::distance(b_first, b_last);
         // The following are tuple extracting aliases
-        std::vector<std::tuple<int64_t, int64_t, int64_t, int64_t>> queue;
+        std::vector<std::tuple<Index, Index, Index, Index>> queue;
         std::vector<match_t> matching_blocks_pass1;
 
         size_t queue_head = 0;
@@ -140,9 +141,9 @@ public:
         queue.emplace_back(0, a_len, 0, b_len);
 
         while (queue_head < queue.size()) {
-            int64_t a_low, a_high, b_low, b_high;
+            Index a_low, a_high, b_low, b_high;
             std::tie(a_low, a_high, b_low, b_high) = queue[queue_head++];
-            int64_t spos, dpos, length;
+            Index spos, dpos, length;
             std::tie(spos, dpos, length) = find_longest_match(a_low, a_high, b_low, b_high);
             if (length) {
                 if (a_low < spos && b_low < dpos) {
@@ -160,7 +161,7 @@ public:
 
         matching_blocks.reserve(matching_blocks_pass1.size());
 
-        int64_t i1, j1, k1;
+        Index i1, j1, k1;
         i1 = j1 = k1 = 0;
 
         for (match_t const& m : matching_blocks_pass1) {
@@ -190,8 +191,8 @@ protected:
 
 private:
     // Cache to avoid reallocations
-    std::vector<int64_t> j2len_;
-    std::unordered_map<iterator_type<InputIt2>, std::vector<int64_t>> b2j_;
+    std::vector<Index> j2len_;
+    std::unordered_map<typename std::iterator_traits<InputIt2>::value_type, std::vector<Index>> b2j_;
 };
 } // namespace difflib
 

--- a/rapidfuzz/details/types.hpp
+++ b/rapidfuzz/details/types.hpp
@@ -63,8 +63,8 @@ template <typename InputIt>
 using IteratorViewVec = std::vector<IteratorView<InputIt>>;
 
 struct StringAffix {
-    int64_t prefix_len;
-    int64_t suffix_len;
+    std::ptrdiff_t prefix_len;
+    std::ptrdiff_t suffix_len;
 };
 
 struct LevenshteinWeightTable {
@@ -95,13 +95,13 @@ enum class EditType {
  */
 struct EditOp {
     EditType type;    /**< type of the edit operation */
-    int64_t src_pos;  /**< index into the source string */
-    int64_t dest_pos; /**< index into the destination string */
+    std::ptrdiff_t src_pos;  /**< index into the source string */
+    std::ptrdiff_t dest_pos; /**< index into the destination string */
 
     EditOp() : type(EditType::None), src_pos(0), dest_pos(0)
     {}
 
-    EditOp(EditType type_, int64_t src_pos_, int64_t dest_pos_)
+    EditOp(EditType type_, std::ptrdiff_t src_pos_, std::ptrdiff_t dest_pos_)
         : type(type_), src_pos(src_pos_), dest_pos(dest_pos_)
     {}
 };
@@ -126,16 +126,16 @@ inline bool operator==(EditOp a, EditOp b)
  */
 struct Opcode {
     EditType type;      /**< type of the edit operation */
-    int64_t src_begin;  /**< index into the source string */
-    int64_t src_end;    /**< index into the source string */
-    int64_t dest_begin; /**< index into the destination string */
-    int64_t dest_end;   /**< index into the destination string */
+    std::ptrdiff_t src_begin;  /**< index into the source string */
+    std::ptrdiff_t src_end;    /**< index into the source string */
+    std::ptrdiff_t dest_begin; /**< index into the destination string */
+    std::ptrdiff_t dest_end;   /**< index into the destination string */
 
     Opcode() : type(EditType::None), src_begin(0), src_end(0), dest_begin(0), dest_end(0)
     {}
 
-    Opcode(EditType type_, int64_t src_begin_, int64_t src_end_, int64_t dest_begin_,
-           int64_t dest_end_)
+    Opcode(EditType type_, std::ptrdiff_t src_begin_, std::ptrdiff_t src_end_,
+           std::ptrdiff_t dest_begin_, std::ptrdiff_t dest_end_)
         : type(type_),
           src_begin(src_begin_),
           src_end(src_end_),
@@ -303,19 +303,19 @@ public:
         return reversed;
     }
 
-    int64_t get_src_len() const
+    std::ptrdiff_t get_src_len() const
     {
         return src_len;
     }
-    void set_src_len(int64_t len)
+    void set_src_len(std::ptrdiff_t len)
     {
         src_len = len;
     }
-    int64_t get_dest_len() const
+    std::ptrdiff_t get_dest_len() const
     {
         return dest_len;
     }
-    void set_dest_len(int64_t len)
+    void set_dest_len(std::ptrdiff_t len)
     {
         dest_len = len;
     }
@@ -337,8 +337,8 @@ public:
     }
 
 private:
-    int64_t src_len;
-    int64_t dest_len;
+    std::ptrdiff_t src_len;
+    std::ptrdiff_t dest_len;
 };
 
 inline bool operator==(const Editops& lhs, const Editops& rhs)
@@ -452,19 +452,19 @@ public:
         return reversed;
     }
 
-    int64_t get_src_len() const
+    std::ptrdiff_t get_src_len() const
     {
         return src_len;
     }
-    void set_src_len(int64_t len)
+    void set_src_len(std::ptrdiff_t len)
     {
         src_len = len;
     }
-    int64_t get_dest_len() const
+    std::ptrdiff_t get_dest_len() const
     {
         return dest_len;
     }
-    void set_dest_len(int64_t len)
+    void set_dest_len(std::ptrdiff_t len)
     {
         dest_len = len;
     }
@@ -487,8 +487,8 @@ public:
     }
 
 private:
-    int64_t src_len;
-    int64_t dest_len;
+    std::ptrdiff_t src_len;
+    std::ptrdiff_t dest_len;
 };
 
 inline bool operator==(const Opcodes& lhs, const Opcodes& rhs)
@@ -523,19 +523,19 @@ inline Editops::Editops(const Opcodes& other)
             break;
 
         case EditType::Replace:
-            for (int64_t j = 0; j < op.src_end - op.src_begin; j++) {
+            for (std::ptrdiff_t j = 0; j < op.src_end - op.src_begin; j++) {
                 push_back({EditType::Replace, op.src_begin + j, op.dest_begin + j});
             }
             break;
 
         case EditType::Insert:
-            for (int64_t j = 0; j < op.dest_end - op.dest_begin; j++) {
+            for (std::ptrdiff_t j = 0; j < op.dest_end - op.dest_begin; j++) {
                 push_back({EditType::Insert, op.src_begin, op.dest_begin + j});
             }
             break;
 
         case EditType::Delete:
-            for (int64_t j = 0; j < op.src_end - op.src_begin; j++) {
+            for (std::ptrdiff_t j = 0; j < op.src_end - op.src_begin; j++) {
                 push_back({EditType::Delete, op.src_begin + j, op.dest_begin});
             }
             break;
@@ -547,8 +547,8 @@ inline Opcodes::Opcodes(const Editops& other)
 {
     src_len = other.get_src_len();
     dest_len = other.get_dest_len();
-    int64_t src_pos = 0;
-    int64_t dest_pos = 0;
+    std::ptrdiff_t src_pos = 0;
+    std::ptrdiff_t dest_pos = 0;
     for (size_t i = 0; i < other.size();) {
         if (src_pos < other[i].src_pos || dest_pos < other[i].dest_pos) {
             push_back({EditType::None, src_pos, other[i].src_pos, dest_pos, other[i].dest_pos});
@@ -556,8 +556,8 @@ inline Opcodes::Opcodes(const Editops& other)
             dest_pos = other[i].dest_pos;
         }
 
-        int64_t src_begin = src_pos;
-        int64_t dest_begin = dest_pos;
+        std::ptrdiff_t src_begin = src_pos;
+        std::ptrdiff_t dest_begin = dest_pos;
         EditType type = other[i].type;
         do {
             switch (type) {
@@ -592,16 +592,16 @@ inline Opcodes::Opcodes(const Editops& other)
 template <typename T>
 struct ScoreAlignment {
     T score;            /**< resulting score of the algorithm */
-    int64_t src_start;  /**< index into the source string */
-    int64_t src_end;    /**< index into the source string */
-    int64_t dest_start; /**< index into the destination string */
-    int64_t dest_end;   /**< index into the destination string */
+    std::ptrdiff_t src_start;  /**< index into the source string */
+    std::ptrdiff_t src_end;    /**< index into the source string */
+    std::ptrdiff_t dest_start; /**< index into the destination string */
+    std::ptrdiff_t dest_end;   /**< index into the destination string */
 
     ScoreAlignment() : score(T()), src_start(0), src_end(0), dest_start(0), dest_end(0)
     {}
 
-    ScoreAlignment(T score_, int64_t src_start_, int64_t src_end_, int64_t dest_start_,
-                   int64_t dest_end_)
+    ScoreAlignment(T score_, std::ptrdiff_t src_start_, std::ptrdiff_t src_end_,
+                   std::ptrdiff_t dest_start_, std::ptrdiff_t dest_end_)
         : score(score_),
           src_start(src_start_),
           src_end(src_end_),

--- a/rapidfuzz/details/types.hpp
+++ b/rapidfuzz/details/types.hpp
@@ -94,7 +94,7 @@ enum class EditType {
  * Delete:  delete character at src_pos
  */
 struct EditOp {
-    EditType type;    /**< type of the edit operation */
+    EditType type;           /**< type of the edit operation */
     std::ptrdiff_t src_pos;  /**< index into the source string */
     std::ptrdiff_t dest_pos; /**< index into the destination string */
 
@@ -125,7 +125,7 @@ inline bool operator==(EditOp a, EditOp b)
  *          Note that dest_begin==dest_end in this case.
  */
 struct Opcode {
-    EditType type;      /**< type of the edit operation */
+    EditType type;             /**< type of the edit operation */
     std::ptrdiff_t src_begin;  /**< index into the source string */
     std::ptrdiff_t src_end;    /**< index into the source string */
     std::ptrdiff_t dest_begin; /**< index into the destination string */
@@ -156,17 +156,17 @@ void vector_slice(std::vector<T>& new_vec, const std::vector<T>& vec, int start,
 {
     if (step > 0) {
         if (start < 0) {
-            start = std::max((int)(start + (int)vec.size()), 0);
+            start = std::max<int>(start + static_cast<int>(vec.size()), 0);
         }
-        else if (start > (int)vec.size()) {
-            start = (int)vec.size();
+        else if (start > static_cast<int>(vec.size())) {
+            start = static_cast<int>(vec.size());
         }
 
         if (stop < 0) {
-            stop = std::max((int)(stop + (int)vec.size()), 0);
+            stop = std::max<int>(stop + static_cast<int>(vec.size()), 0);
         }
-        else if (stop > (int)vec.size()) {
-            stop = (int)vec.size();
+        else if (stop > static_cast<int>(vec.size())) {
+            stop = static_cast<int>(vec.size());
         }
 
         if (start >= stop) {
@@ -182,17 +182,17 @@ void vector_slice(std::vector<T>& new_vec, const std::vector<T>& vec, int start,
     }
     else if (step < 0) {
         if (start < 0) {
-            start = std::max((int)(start + (int)vec.size()), -1);
+            start = std::max<int>(start + static_cast<int>(vec.size()), -1);
         }
-        else if (start >= (int)vec.size()) {
-            start = (int)vec.size() - 1;
+        else if (start >= static_cast<int>(vec.size())) {
+            start = static_cast<int>(vec.size()) - 1;
         }
 
         if (stop < 0) {
-            stop = std::max((int)(stop + (int)vec.size()), -1);
+            stop = std::max<int>(stop + static_cast<int>(vec.size()), -1);
         }
-        else if (stop >= (int)vec.size()) {
-            stop = (int)vec.size() - 1;
+        else if (stop >= static_cast<int>(vec.size())) {
+            stop = static_cast<int>(vec.size()) - 1;
         }
 
         if (start <= stop) {
@@ -218,17 +218,21 @@ class Editops : private std::vector<EditOp> {
 public:
     using std::vector<EditOp>::size_type;
 
-    Editops() : src_len(0), dest_len(0)
+    Editops() noexcept : src_len(0), dest_len(0)
     {}
 
-    Editops(size_type count, const EditOp& value)
+    Editops(size_type count, const EditOp& value) noexcept(
+        std::is_nothrow_constructible<std::vector<EditOp>, size_type, const EditOp&>::value)
         : std::vector<EditOp>(count, value), src_len(0), dest_len(0)
     {}
 
-    explicit Editops(size_type count) : std::vector<EditOp>(count), src_len(0), dest_len(0)
+    explicit Editops(size_type count) noexcept(
+        std::is_nothrow_constructible<std::vector<EditOp>, size_type>::value)
+        : std::vector<EditOp>(count), src_len(0), dest_len(0)
     {}
 
-    Editops(const Editops& other)
+    Editops(const Editops& other) noexcept(
+        std::is_nothrow_copy_constructible<std::vector<EditOp>>::value)
         : std::vector<EditOp>(other), src_len(other.src_len), dest_len(other.dest_len)
     {}
 
@@ -239,7 +243,7 @@ public:
         swap(other);
     }
 
-    Editops& operator=(Editops other)
+    Editops& operator=(Editops other) noexcept
     {
         swap(other);
         return *this;
@@ -303,19 +307,19 @@ public:
         return reversed;
     }
 
-    std::ptrdiff_t get_src_len() const
+    std::ptrdiff_t get_src_len() const noexcept
     {
         return src_len;
     }
-    void set_src_len(std::ptrdiff_t len)
+    void set_src_len(std::ptrdiff_t len) noexcept
     {
         src_len = len;
     }
-    std::ptrdiff_t get_dest_len() const
+    std::ptrdiff_t get_dest_len() const noexcept
     {
         return dest_len;
     }
-    void set_dest_len(std::ptrdiff_t len)
+    void set_dest_len(std::ptrdiff_t len) noexcept
     {
         dest_len = len;
     }
@@ -358,7 +362,7 @@ inline bool operator!=(const Editops& lhs, const Editops& rhs)
     return !(lhs == rhs);
 }
 
-inline void swap(Editops& lhs, Editops& rhs)
+inline void swap(Editops& lhs, Editops& rhs) noexcept(noexcept(lhs.swap(rhs)))
 {
     lhs.swap(rhs);
 }
@@ -367,17 +371,21 @@ class Opcodes : private std::vector<Opcode> {
 public:
     using std::vector<Opcode>::size_type;
 
-    Opcodes() : src_len(0), dest_len(0)
+    Opcodes() noexcept : src_len(0), dest_len(0)
     {}
 
-    Opcodes(size_type count, const Opcode& value)
+    Opcodes(size_type count, const Opcode& value) noexcept(
+        std::is_nothrow_constructible<std::vector<Opcode>, size_type, const Opcode&>::value)
         : std::vector<Opcode>(count, value), src_len(0), dest_len(0)
     {}
 
-    explicit Opcodes(size_type count) : std::vector<Opcode>(count), src_len(0), dest_len(0)
+    explicit Opcodes(size_type count) noexcept(
+        std::is_nothrow_constructible<std::vector<Opcode>, size_type>::value)
+        : std::vector<Opcode>(count), src_len(0), dest_len(0)
     {}
 
-    Opcodes(const Opcodes& other)
+    Opcodes(const Opcodes& other) noexcept(
+        std::is_nothrow_copy_constructible<std::vector<Opcode>>::value)
         : std::vector<Opcode>(other), src_len(other.src_len), dest_len(other.dest_len)
     {}
 
@@ -388,7 +396,7 @@ public:
         swap(other);
     }
 
-    Opcodes& operator=(Opcodes other)
+    Opcodes& operator=(Opcodes other) noexcept
     {
         swap(other);
         return *this;
@@ -452,19 +460,19 @@ public:
         return reversed;
     }
 
-    std::ptrdiff_t get_src_len() const
+    std::ptrdiff_t get_src_len() const noexcept
     {
         return src_len;
     }
-    void set_src_len(std::ptrdiff_t len)
+    void set_src_len(std::ptrdiff_t len) noexcept
     {
         src_len = len;
     }
-    std::ptrdiff_t get_dest_len() const
+    std::ptrdiff_t get_dest_len() const noexcept
     {
         return dest_len;
     }
-    void set_dest_len(std::ptrdiff_t len)
+    void set_dest_len(std::ptrdiff_t len) noexcept
     {
         dest_len = len;
     }
@@ -508,7 +516,7 @@ inline bool operator!=(const Opcodes& lhs, const Opcodes& rhs)
     return !(lhs == rhs);
 }
 
-inline void swap(Opcodes& lhs, Opcodes& rhs)
+inline void swap(Opcodes& lhs, Opcodes& rhs) noexcept(noexcept(lhs.swap(rhs)))
 {
     lhs.swap(rhs);
 }
@@ -591,7 +599,7 @@ inline Opcodes::Opcodes(const Editops& other)
 
 template <typename T>
 struct ScoreAlignment {
-    T score;            /**< resulting score of the algorithm */
+    T score;                   /**< resulting score of the algorithm */
     std::ptrdiff_t src_start;  /**< index into the source string */
     std::ptrdiff_t src_end;    /**< index into the source string */
     std::ptrdiff_t dest_start; /**< index into the destination string */

--- a/rapidfuzz/details/types.hpp
+++ b/rapidfuzz/details/types.hpp
@@ -221,18 +221,15 @@ public:
     Editops() noexcept : src_len(0), dest_len(0)
     {}
 
-    Editops(size_type count, const EditOp& value) noexcept(
-        std::is_nothrow_constructible<std::vector<EditOp>, size_type, const EditOp&>::value)
+    Editops(size_type count, const EditOp& value)
         : std::vector<EditOp>(count, value), src_len(0), dest_len(0)
     {}
 
-    explicit Editops(size_type count) noexcept(
-        std::is_nothrow_constructible<std::vector<EditOp>, size_type>::value)
+    explicit Editops(size_type count)
         : std::vector<EditOp>(count), src_len(0), dest_len(0)
     {}
 
-    Editops(const Editops& other) noexcept(
-        std::is_nothrow_copy_constructible<std::vector<EditOp>>::value)
+    Editops(const Editops& other)
         : std::vector<EditOp>(other), src_len(other.src_len), dest_len(other.dest_len)
     {}
 
@@ -374,18 +371,15 @@ public:
     Opcodes() noexcept : src_len(0), dest_len(0)
     {}
 
-    Opcodes(size_type count, const Opcode& value) noexcept(
-        std::is_nothrow_constructible<std::vector<Opcode>, size_type, const Opcode&>::value)
+    Opcodes(size_type count, const Opcode& value)
         : std::vector<Opcode>(count, value), src_len(0), dest_len(0)
     {}
 
-    explicit Opcodes(size_type count) noexcept(
-        std::is_nothrow_constructible<std::vector<Opcode>, size_type>::value)
+    explicit Opcodes(size_type count)
         : std::vector<Opcode>(count), src_len(0), dest_len(0)
     {}
 
-    Opcodes(const Opcodes& other) noexcept(
-        std::is_nothrow_copy_constructible<std::vector<Opcode>>::value)
+    Opcodes(const Opcodes& other)
         : std::vector<Opcode>(other), src_len(other.src_len), dest_len(other.dest_len)
     {}
 

--- a/rapidfuzz/distance.hpp
+++ b/rapidfuzz/distance.hpp
@@ -13,13 +13,13 @@ template <typename CharT, typename InputIt1, typename InputIt2>
 std::basic_string<CharT> editops_apply(const Editops& ops, InputIt1 first1, InputIt1 last1,
                                        InputIt2 first2, InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     std::basic_string<CharT> res_str;
     res_str.resize(len1 + len2);
-    int64_t src_pos = 0;
-    int64_t dest_pos = 0;
+    std::ptrdiff_t src_pos = 0;
+    std::ptrdiff_t dest_pos = 0;
 
     for (const auto& op : ops) {
         /* matches between last and current editop */
@@ -68,12 +68,12 @@ template <typename CharT, typename InputIt1, typename InputIt2>
 std::basic_string<CharT> opcodes_apply(const Opcodes& ops, InputIt1 first1, InputIt1 last1,
                                        InputIt2 first2, InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     std::basic_string<CharT> res_str;
     res_str.resize(len1 + len2);
-    int64_t dest_pos = 0;
+    std::ptrdiff_t dest_pos = 0;
 
     for (const auto& op : ops) {
         switch (op.type) {

--- a/rapidfuzz/distance/Hamming.impl
+++ b/rapidfuzz/distance/Hamming.impl
@@ -34,7 +34,7 @@ template <typename InputIt1, typename InputIt2>
 int64_t hamming_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                            int64_t score_cutoff)
 {
-    int64_t maximum = std::distance(first1, last1);
+    auto maximum = std::distance(first1, last1);
     int64_t cutoff_distance = maximum - score_cutoff;
     int64_t dist = hamming_distance(first1, last1, first2, last2, cutoff_distance);
     int64_t sim = maximum - dist;
@@ -52,8 +52,8 @@ template <typename InputIt1, typename InputIt2>
 double hamming_normalized_distance(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                                    double score_cutoff)
 {
-    int64_t maximum = std::distance(first1, last1);
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    auto maximum = std::distance(first1, last1);
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = hamming_distance(first1, last1, first2, last2, cutoff_distance);
     double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
@@ -70,10 +70,10 @@ template <typename InputIt1, typename InputIt2>
 double hamming_normalized_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                      InputIt2 last2, double score_cutoff)
 {
-    int64_t maximum = std::distance(first1, last1);
-    int64_t cutoff_distance = maximum - score_cutoff;
+    auto maximum = std::distance(first1, last1);
+    int64_t cutoff_distance = maximum - static_cast<std::ptrdiff_t>(score_cutoff);
     int64_t dist = hamming_distance(first1, last1, first2, last2, cutoff_distance);
-    int64_t sim = maximum - dist;
+    double sim = maximum - dist;
     return (sim >= score_cutoff) ? sim : 0;
 }
 

--- a/rapidfuzz/distance/Hamming.impl
+++ b/rapidfuzz/distance/Hamming.impl
@@ -55,7 +55,7 @@ double hamming_normalized_distance(InputIt1 first1, InputIt1 last1, InputIt2 fir
     auto maximum = std::distance(first1, last1);
     int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = hamming_distance(first1, last1, first2, last2, cutoff_distance);
-    double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
+    double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 

--- a/rapidfuzz/distance/Indel.impl
+++ b/rapidfuzz/distance/Indel.impl
@@ -35,9 +35,9 @@ double indel_normalized_distance(const common::BlockPatternMatchVector& block, I
                                  double score_cutoff)
 {
     int64_t maximum = std::distance(first1, last1) + std::distance(first2, last2);
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = indel_distance(block, first1, last1, first2, last2, cutoff_distance);
-    double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
+    double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 
@@ -46,7 +46,7 @@ int64_t indel_similarity(const common::BlockPatternMatchVector& block, InputIt1 
                          InputIt1 last1, InputIt2 first2, InputIt2 last2, int64_t score_cutoff)
 {
     int64_t maximum = std::distance(first1, last1) + std::distance(first2, last2);
-    int64_t cutoff_distance = std::max((int64_t)0, maximum - score_cutoff);
+    int64_t cutoff_distance = std::max<int64_t>(0, maximum - score_cutoff);
     int64_t dist = indel_distance(block, first1, last1, first2, last2, cutoff_distance);
     int64_t sim = maximum - dist;
     return (sim >= score_cutoff) ? sim : 0;
@@ -84,9 +84,9 @@ double indel_normalized_distance(InputIt1 first1, InputIt1 last1, InputIt2 first
                                  double score_cutoff)
 {
     int64_t maximum = std::distance(first1, last1) + std::distance(first2, last2);
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = indel_distance(first1, last1, first2, last2, cutoff_distance);
-    double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
+    double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 
@@ -102,7 +102,7 @@ int64_t indel_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2, Input
                          int64_t score_cutoff)
 {
     int64_t maximum = std::distance(first1, last1) + std::distance(first2, last2);
-    int64_t cutoff_distance = std::max((int64_t)0, maximum - score_cutoff);
+    int64_t cutoff_distance = std::max<int64_t>(0, maximum - score_cutoff);
     int64_t dist = indel_distance(first1, last1, first2, last2, cutoff_distance);
     int64_t sim = maximum - dist;
     return (sim >= score_cutoff) ? sim : 0;
@@ -164,9 +164,9 @@ double CachedIndel<CharT1>::normalized_distance(InputIt2 first2, InputIt2 last2,
                                                 double score_cutoff) const
 {
     int64_t maximum = s1.size() + std::distance(first2, last2);
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = distance(first2, last2, cutoff_distance);
-    double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
+    double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 

--- a/rapidfuzz/distance/Indel.impl
+++ b/rapidfuzz/distance/Indel.impl
@@ -12,7 +12,7 @@ int64_t indel_distance(const common::BlockPatternMatchVector& block, InputIt1 fi
                        InputIt1 last1, InputIt2 first2, InputIt2 last2, int64_t score_cutoff)
 {
     int64_t maximum = std::distance(first1, last1) + std::distance(first2, last2);
-    int64_t lcs_cutoff = std::max((int64_t)0, maximum / 2 - score_cutoff);
+    int64_t lcs_cutoff = std::max<int64_t>(0, maximum / 2 - score_cutoff);
     int64_t lcs_sim = detail::lcs_seq_similarity(block, first1, last1, first2, last2, lcs_cutoff);
     int64_t dist = maximum - 2 * lcs_sim;
     return (dist <= score_cutoff) ? dist : score_cutoff + 1;
@@ -23,7 +23,7 @@ int64_t indel_distance(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt
                        int64_t score_cutoff)
 {
     int64_t maximum = std::distance(first1, last1) + std::distance(first2, last2);
-    int64_t lcs_cutoff = std::max((int64_t)0, maximum / 2 - score_cutoff);
+    int64_t lcs_cutoff = std::max<int64_t>(0, maximum / 2 - score_cutoff);
     int64_t lcs_sim = lcs_seq_similarity(first1, last1, first2, last2, lcs_cutoff);
     int64_t dist = maximum - 2 * lcs_sim;
     return (dist <= score_cutoff) ? dist : score_cutoff + 1;

--- a/rapidfuzz/distance/LCSseq.impl
+++ b/rapidfuzz/distance/LCSseq.impl
@@ -132,7 +132,7 @@ longest_common_subsequence_blockwise(const common::BlockPatternMatchVector& bloc
                                      InputIt1, InputIt2 first2, InputIt2 last2,
                                      int64_t score_cutoff)
 {
-    std::ptrdiff_t words = block.m_val.size();
+    auto words = static_cast<std::ptrdiff_t>(block.m_val.size());
     std::vector<uint64_t> S(words, ~0x0ull);
 
     for (; first2 != last2; ++first2) {
@@ -457,7 +457,7 @@ LLCSBitMatrix llcs_matrix_blockwise(const common::BlockPatternMatchVector& block
 {
     auto len1 = std::distance(first1, last1);
     auto len2 = std::distance(first2, last2);
-    auto words = block.m_val.size();
+    auto words = static_cast<std::ptrdiff_t>(block.m_val.size());
     /* todo could be replaced with access to matrix which would slightly
      * reduce memory usage */
     std::vector<uint64_t> S(words, ~0x0ull);
@@ -532,7 +532,7 @@ int64_t lcs_seq_distance(InputIt1 first1, InputIt1 last1, InputIt2 first2, Input
                          int64_t score_cutoff)
 {
     int64_t maximum = std::max(std::distance(first1, last1), std::distance(first2, last2));
-    int64_t cutoff_similarity = std::max(static_cast<int64_t>(0), maximum - score_cutoff);
+    int64_t cutoff_similarity = std::max<int64_t>(0, maximum - score_cutoff);
     int64_t sim = lcs_seq_similarity(first1, last1, first2, last2, cutoff_similarity);
     int64_t dist = maximum - sim;
     return (dist <= score_cutoff) ? dist : score_cutoff + 1;
@@ -553,9 +553,9 @@ double lcs_seq_normalized_distance(InputIt1 first1, InputIt1 last1, InputIt2 fir
     if (maximum == 0) {
         return 0.0;
     }
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     double norm_sim =
-        (double)lcs_seq_distance(first1, last1, first2, last2, cutoff_distance) / (double)maximum;
+        static_cast<double>(lcs_seq_distance(first1, last1, first2, last2, cutoff_distance)) / static_cast<double>(maximum);
     return (norm_sim <= score_cutoff) ? norm_sim : 1.0;
 }
 
@@ -617,7 +617,7 @@ template <typename CharT1>
 template <typename InputIt2>
 int64_t CachedLCSseq<CharT1>::distance(InputIt2 first2, InputIt2 last2, int64_t score_cutoff) const
 {
-    int64_t maximum = std::max((int64_t)s1.size(), (int64_t)std::distance(first2, last2));
+    int64_t maximum = std::max<int64_t>(s1.size(), std::distance(first2, last2));
     int64_t cutoff_distance = maximum - score_cutoff;
     int64_t sim = maximum - distance(first2, last2, cutoff_distance);
     return (sim >= score_cutoff) ? sim : 0;
@@ -635,12 +635,12 @@ template <typename InputIt2>
 double CachedLCSseq<CharT1>::normalized_distance(InputIt2 first2, InputIt2 last2,
                                                  double score_cutoff) const
 {
-    int64_t maximum = std::max((int64_t)s1.size(), (int64_t)std::distance(first2, last2));
+    int64_t maximum = std::max<int64_t>(s1.size(), std::distance(first2, last2));
     if (maximum == 0) {
         return 0;
     }
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
-    double norm_dist = (double)distance(first2, last2, cutoff_distance) / (double)maximum;
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
+    double norm_dist = static_cast<double>(distance(first2, last2, cutoff_distance)) / static_cast<double>(maximum);
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 

--- a/rapidfuzz/distance/LCSseq.impl
+++ b/rapidfuzz/distance/LCSseq.impl
@@ -54,23 +54,23 @@ template <typename InputIt1, typename InputIt2>
 int64_t lcs_seq_mbleven2018(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                             int64_t score_cutoff)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     if (len1 < len2) {
         return lcs_seq_mbleven2018(first2, last2, first1, last1, score_cutoff);
     }
 
-    int64_t len_diff = len1 - len2;
-    int64_t max_misses = len1 - score_cutoff;
+    auto len_diff = len1 - len2;
+    int64_t max_misses = static_cast<std::ptrdiff_t>(len1) - score_cutoff;
     auto possible_ops =
         lcs_seq_mbleven2018_matrix[(max_misses + max_misses * max_misses) / 2 + len_diff - 1];
     int64_t max_len = 0;
 
     for (int pos = 0; possible_ops[pos] != 0; ++pos) {
         uint8_t ops = possible_ops[pos];
-        int64_t s1_pos = 0;
-        int64_t s2_pos = 0;
+        std::ptrdiff_t s1_pos = 0;
+        std::ptrdiff_t s2_pos = 0;
         int64_t cur_len = 0;
 
         while (s1_pos < len1 && s2_pos < len2) {
@@ -95,7 +95,7 @@ int64_t lcs_seq_mbleven2018(InputIt1 first1, InputIt1 last1, InputIt2 first2, In
     return (max_len >= score_cutoff) ? max_len : 0;
 }
 
-template <int64_t N, typename PMV, typename InputIt1, typename InputIt2>
+template <std::ptrdiff_t N, typename PMV, typename InputIt1, typename InputIt2>
 static inline int64_t longest_common_subsequence_unroll(const PMV& block, InputIt1, InputIt1,
                                                         InputIt2 first2, InputIt2 last2,
                                                         int64_t score_cutoff)
@@ -110,7 +110,7 @@ static inline int64_t longest_common_subsequence_unroll(const PMV& block, InputI
         uint64_t Matches[N];
         uint64_t u[N];
         uint64_t x[N];
-        for (int64_t i = 0; i < N; ++i) {
+        for (std::ptrdiff_t i = 0; i < N; ++i) {
             Matches[i] = block.get(i, *first2);
             u[i] = S[i] & Matches[i];
             x[i] = addc64(S[i], u[i], carry, &carry);
@@ -132,12 +132,12 @@ longest_common_subsequence_blockwise(const common::BlockPatternMatchVector& bloc
                                      InputIt1, InputIt2 first2, InputIt2 last2,
                                      int64_t score_cutoff)
 {
-    int64_t words = block.m_val.size();
+    std::ptrdiff_t words = block.m_val.size();
     std::vector<uint64_t> S(words, ~0x0ull);
 
     for (; first2 != last2; ++first2) {
         uint64_t carry = 0;
-        for (int64_t word = 0; word < words; ++word) {
+        for (std::ptrdiff_t word = 0; word < words; ++word) {
             const uint64_t Matches = block.get(word, *first2);
             uint64_t Stemp = S[word];
 
@@ -161,7 +161,7 @@ int64_t longest_common_subsequence(const common::BlockPatternMatchVector& block,
                                    InputIt1 last1, InputIt2 first2, InputIt2 last2,
                                    int64_t score_cutoff)
 {
-    int64_t nr = ceil_div(std::distance(first1, last1), 64);
+    auto nr = ceil_div(std::distance(first1, last1), 64);
     switch (nr) {
     case 0:
         return 0;
@@ -199,8 +199,8 @@ template <typename InputIt1, typename InputIt2>
 int64_t longest_common_subsequence(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                                    int64_t score_cutoff)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t nr = ceil_div(len1, 64);
+    auto len1 = std::distance(first1, last1);
+    auto nr = ceil_div(len1, 64);
     switch (nr) {
     case 0:
         return 0;
@@ -265,9 +265,9 @@ template <typename InputIt1, typename InputIt2>
 int64_t lcs_seq_similarity(const common::BlockPatternMatchVector& block, InputIt1 first1,
                            InputIt1 last1, InputIt2 first2, InputIt2 last2, int64_t score_cutoff)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
-    int64_t max_misses = len1 + len2 - 2 * score_cutoff;
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
+    int64_t max_misses = static_cast<int64_t>(len1) + len2 - 2 * score_cutoff;
 
     /* no edits are allowed */
     if (max_misses == 0 || (max_misses == 1 && len1 == len2)) {
@@ -285,7 +285,7 @@ int64_t lcs_seq_similarity(const common::BlockPatternMatchVector& block, InputIt
 
     /* common affix does not effect Levenshtein distance */
     auto affix = common::remove_common_affix(first1, last1, first2, last2);
-    auto lcs_sim = affix.prefix_len + affix.suffix_len;
+    int64_t lcs_sim = affix.prefix_len + affix.suffix_len;
     if (std::distance(first1, last1) && std::distance(first2, last2)) {
         lcs_sim += lcs_seq_mbleven2018(first1, last1, first2, last2, score_cutoff - lcs_sim);
     }
@@ -297,14 +297,14 @@ template <typename InputIt1, typename InputIt2>
 int64_t lcs_seq_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                            int64_t score_cutoff)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     // Swapping the strings so the second string is shorter
     if (len1 < len2) {
         return lcs_seq_similarity(first2, last2, first1, last1, score_cutoff);
     }
-    int64_t max_misses = len1 + len2 - 2 * score_cutoff;
+    int64_t max_misses = static_cast<int64_t>(len1) + len2 - 2 * score_cutoff;
 
     /* no edits are allowed */
     if (max_misses == 0 || (max_misses == 1 && len1 == len2)) {
@@ -317,7 +317,7 @@ int64_t lcs_seq_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
 
     /* common affix does not effect Levenshtein distance */
     auto affix = common::remove_common_affix(first1, last1, first2, last2);
-    auto lcs_sim = affix.prefix_len + affix.suffix_len;
+    int64_t lcs_sim = affix.prefix_len + affix.suffix_len;
     if (std::distance(first1, last1) && std::distance(first2, last2)) {
         if (max_misses < 5) {
             lcs_sim += lcs_seq_mbleven2018(first1, last1, first2, last2, score_cutoff - lcs_sim);
@@ -332,12 +332,13 @@ int64_t lcs_seq_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
 }
 
 struct LLCSBitMatrix {
-    LLCSBitMatrix(uint64_t rows, uint64_t cols) : S(rows, cols, (uint64_t)-1), dist(0)
+    LLCSBitMatrix(std::size_t rows, std::size_t cols)
+        : S(rows, cols, static_cast<decltype(S)::value_type>(-1)), dist(0)
     {}
 
     common::Matrix<uint64_t> S;
 
-    int64_t dist;
+    std::ptrdiff_t dist;
 };
 
 /**
@@ -347,9 +348,9 @@ template <typename InputIt1, typename InputIt2>
 Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                           const LLCSBitMatrix& matrix, StringAffix affix)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
-    int64_t dist = matrix.dist;
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
+    std::ptrdiff_t dist = matrix.dist;
     Editops editops(dist);
     editops.set_src_len(len1 + affix.prefix_len + affix.suffix_len);
     editops.set_dest_len(len2 + affix.prefix_len + affix.suffix_len);
@@ -358,8 +359,8 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
         return editops;
     }
 
-    int64_t col = len1;
-    int64_t row = len2;
+    auto col = len1;
+    auto row = len2;
 
     while (row && col) {
         uint64_t col_pos = col - 1;
@@ -414,25 +415,25 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
     return editops;
 }
 
-template <int64_t N, typename PMV, typename InputIt1, typename InputIt2>
+template <std::ptrdiff_t N, typename PMV, typename InputIt1, typename InputIt2>
 LLCSBitMatrix llcs_matrix_unroll(const PMV& block, InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                  InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
     uint64_t S[N];
-    for (int64_t i = 0; i < N; ++i) {
+    for (std::ptrdiff_t i = 0; i < N; ++i) {
         S[i] = ~0x0ull;
     }
 
     LLCSBitMatrix matrix(len2, N);
 
-    for (int64_t i = 0; i < len2; ++i) {
+    for (std::ptrdiff_t i = 0; i < len2; ++i) {
         uint64_t carry = 0;
         uint64_t Matches[N];
         uint64_t u[N];
         uint64_t x[N];
-        for (int64_t word = 0; word < N; ++word) {
+        for (std::ptrdiff_t word = 0; word < N; ++word) {
             Matches[word] = block.get(word, first2[i]);
             u[word] = S[word] & Matches[word];
             x[word] = addc64(S[word], u[word], carry, &carry);
@@ -445,7 +446,7 @@ LLCSBitMatrix llcs_matrix_unroll(const PMV& block, InputIt1 first1, InputIt1 las
         res += popcount64(~S[i]);
     }
 
-    matrix.dist = len1 + len2 - 2 * res;
+    matrix.dist = static_cast<std::ptrdiff_t>(static_cast<int64_t>(len1) + len2 - 2 * res);
 
     return matrix;
 }
@@ -454,17 +455,17 @@ template <typename InputIt1, typename InputIt2>
 LLCSBitMatrix llcs_matrix_blockwise(const common::BlockPatternMatchVector& block, InputIt1 first1,
                                     InputIt1 last1, InputIt2 first2, InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
-    int64_t words = block.m_val.size();
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
+    auto words = block.m_val.size();
     /* todo could be replaced with access to matrix which would slightly
      * reduce memory usage */
     std::vector<uint64_t> S(words, ~0x0ull);
     LLCSBitMatrix matrix(len2, words);
 
-    for (int64_t i = 0; i < len2; ++i) {
+    for (std::ptrdiff_t i = 0; i < len2; ++i) {
         uint64_t carry = 0;
-        for (int64_t word = 0; word < words; ++word) {
+        for (std::ptrdiff_t word = 0; word < words; ++word) {
             const uint64_t Matches = block.get(word, first2[i]);
             uint64_t Stemp = S[word];
 
@@ -480,7 +481,7 @@ LLCSBitMatrix llcs_matrix_blockwise(const common::BlockPatternMatchVector& block
         res += popcount64(~Stemp);
     }
 
-    matrix.dist = len1 + len2 - 2 * res;
+    matrix.dist = static_cast<std::ptrdiff_t>(static_cast<std::int64_t>(len1) + len2 - 2 * res);
 
     return matrix;
 }
@@ -488,8 +489,8 @@ LLCSBitMatrix llcs_matrix_blockwise(const common::BlockPatternMatchVector& block
 template <typename InputIt1, typename InputIt2>
 LLCSBitMatrix llcs_matrix(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
     if (!len1 || !len2) {
         LLCSBitMatrix matrix(0, 0);
         matrix.dist = len1 + len2;
@@ -531,7 +532,7 @@ int64_t lcs_seq_distance(InputIt1 first1, InputIt1 last1, InputIt2 first2, Input
                          int64_t score_cutoff)
 {
     int64_t maximum = std::max(std::distance(first1, last1), std::distance(first2, last2));
-    int64_t cutoff_similarity = std::max((int64_t)0, maximum - score_cutoff);
+    int64_t cutoff_similarity = std::max(static_cast<int64_t>(0), maximum - score_cutoff);
     int64_t sim = lcs_seq_similarity(first1, last1, first2, last2, cutoff_similarity);
     int64_t dist = maximum - sim;
     return (dist <= score_cutoff) ? dist : score_cutoff + 1;

--- a/rapidfuzz/distance/Levenshtein.hpp
+++ b/rapidfuzz/distance/Levenshtein.hpp
@@ -53,16 +53,16 @@ namespace rapidfuzz {
  *      the Levenshtein distance, so the affix is removed before calculating the
  *      similarity.
  *
- *    - If max is ≤ 3 the mbleven algorithm is used. This algorithm
+ *    - If max is <= 3 the mbleven algorithm is used. This algorithm
  *      checks all possible edit operations that are possible under
  *      the threshold `max`. The time complexity of this algorithm is ``O(N)``.
  *
- *    - If the length of the shorter string is ≤ 64 after removing the common affix
+ *    - If the length of the shorter string is <= 64 after removing the common affix
  *      Hyyrös' algorithm is used, which calculates the Levenshtein distance in
  *      parallel. The algorithm is described by @cite hyrro_2002. The time complexity of this
  *      algorithm is ``O(N)``.
  *
- *    - If the length of the shorter string is ≥ 64 after removing the common affix
+ *    - If the length of the shorter string is >= 64 after removing the common affix
  *      a blockwise implementation of Myers' algorithm is used, which calculates
  *      the Levenshtein distance in parallel (64 characters at a time).
  *      The algorithm is described by @cite myers_1999. The time complexity of this
@@ -89,20 +89,20 @@ namespace rapidfuzz {
  *      the Levenshtein distance, so the affix is removed before calculating the
  *      similarity.
  *
- *    - If max is ≤ 4 the mbleven algorithm is used. This algorithm
+ *    - If max is <= 4 the mbleven algorithm is used. This algorithm
  *      checks all possible edit operations that are possible under
  *      the threshold `max`. As a difference to the normal Levenshtein distance this
  *      algorithm can even be used up to a threshold of 4 here, since the higher weight
  *      of substitutions decreases the amount of possible edit operations.
  *      The time complexity of this algorithm is ``O(N)``.
  *
- *    - If the length of the shorter string is ≤ 64 after removing the common affix
+ *    - If the length of the shorter string is <= 64 after removing the common affix
  *      Hyyrös' lcs algorithm is used, which calculates the InDel distance in
  *      parallel. The algorithm is described by @cite hyrro_lcs_2004 and is extended with support
  *      for UTF32 in this implementation. The time complexity of this
  *      algorithm is ``O(N)``.
  *
- *    - If the length of the shorter string is ≥ 64 after removing the common affix
+ *    - If the length of the shorter string is >= 64 after removing the common affix
  *      a blockwise implementation of Hyyrös' lcs algorithm is used, which calculates
  *      the Levenshtein distance in parallel (64 characters at a time).
  *      The algorithm is described by @cite hyrro_lcs_2004. The time complexity of this

--- a/rapidfuzz/distance/Levenshtein.impl
+++ b/rapidfuzz/distance/Levenshtein.impl
@@ -493,7 +493,7 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
         std::size_t col_pos = col - 1;
         std::size_t col_word = col_pos / 64;
         col_pos = col_pos % 64;
-        std::size_t mask = static_cast<std::size_t>(1) << col_pos;
+        uint64_t mask = static_cast<std::uint64_t>(1) << col_pos;
 
         /* Deletion */
         if (matrix.VP[row - 1][col_word] & mask) {

--- a/rapidfuzz/distance/Levenshtein.impl
+++ b/rapidfuzz/distance/Levenshtein.impl
@@ -11,12 +11,12 @@ int64_t generalized_levenshtein_wagner_fischer(InputIt1 first1, InputIt1 last1, 
                                                InputIt2 last2, LevenshteinWeightTable weights,
                                                int64_t max)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t cache_size = len1 + 1;
+    auto len1 = std::distance(first1, last1);
+    auto cache_size = len1 + 1;
     std::vector<int64_t> cache(cache_size);
 
     cache[0] = 0;
-    for (int64_t i = 1; i < cache_size; ++i) {
+    for (std::ptrdiff_t i = 1; i < cache_size; ++i) {
         cache[i] = cache[i - 1] + (int64_t)weights.delete_cost;
     }
 
@@ -49,18 +49,18 @@ template <typename InputIt1, typename InputIt2>
 int64_t levenshtein_maximum(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                             LevenshteinWeightTable weights)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
-    int64_t max_dist = len1 * (int64_t)weights.delete_cost + len2 * (int64_t)weights.insert_cost;
+    int64_t max_dist = len1 * weights.delete_cost + len2 * weights.insert_cost;
 
     if (len1 >= len2) {
-        max_dist = std::min(max_dist, len2 * (int64_t)weights.replace_cost +
-                                          (len1 - len2) * (int64_t)weights.delete_cost);
+        max_dist = std::min(max_dist, len2 * weights.replace_cost +
+                                          (len1 - len2) * weights.delete_cost);
     }
     else {
-        max_dist = std::min(max_dist, len1 * (int64_t)weights.replace_cost +
-                                          (len2 - len1) * (int64_t)weights.insert_cost);
+        max_dist = std::min(max_dist, len1 * weights.replace_cost +
+                                          (len2 - len1) * weights.insert_cost);
     }
 
     return max_dist;
@@ -74,10 +74,10 @@ template <typename InputIt1, typename InputIt2>
 int64_t levenshtein_min_distance(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                                  LevenshteinWeightTable weights)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
-    return std::max((len1 - len2) * (int64_t)weights.delete_cost,
-                    (len2 - len1) * (int64_t)weights.insert_cost);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
+    return std::max((len1 - len2) * weights.delete_cost,
+                    (len2 - len1) * weights.insert_cost);
 }
 
 template <typename InputIt1, typename InputIt2>
@@ -130,21 +130,21 @@ template <typename InputIt1, typename InputIt2>
 int64_t levenshtein_mbleven2018(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                                 int64_t max)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     if (len1 < len2) {
         return levenshtein_mbleven2018(first2, last2, first1, last1, max);
     }
 
-    int64_t len_diff = len1 - len2;
+    auto len_diff = len1 - len2;
     auto possible_ops = levenshtein_mbleven2018_matrix[(max + max * max) / 2 + len_diff - 1];
     int64_t dist = max + 1;
 
     for (int pos = 0; possible_ops[pos] != 0; ++pos) {
         uint8_t ops = possible_ops[pos];
-        int64_t s1_pos = 0;
-        int64_t s2_pos = 0;
+        std::ptrdiff_t s1_pos = 0;
+        std::ptrdiff_t s2_pos = 0;
         int64_t cur_dist = 0;
         while (s1_pos < len1 && s2_pos < len2) {
             if (first1[s1_pos] != first2[s2_pos]) {
@@ -188,7 +188,7 @@ template <typename InputIt1, typename InputIt2>
 int64_t levenshtein_hyrroe2003(const common::PatternMatchVector& PM, InputIt1 first1,
                                InputIt1 last1, InputIt2 first2, InputIt2 last2, int64_t max)
 {
-    int64_t len1 = std::distance(first1, last1);
+    auto len1 = std::distance(first1, last1);
 
     /* VP is set to 1^m. Shifting by bitwidth would be undefined behavior */
     uint64_t VP = (uint64_t)-1;
@@ -229,8 +229,8 @@ int64_t levenshtein_hyrroe2003_small_band(const common::BlockPatternMatchVector&
                                           InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                           InputIt2 last2, int64_t max)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     /* VP is set to 1^m. Shifting by bitwidth would be undefined behavior */
     uint64_t VP = (uint64_t)-1;
@@ -244,10 +244,10 @@ int64_t levenshtein_hyrroe2003_small_band(const common::BlockPatternMatchVector&
     const int64_t words = PM.m_val.size();
 
     /* Searching */
-    for (int64_t i = 0; i < len2; ++i) {
+    for (std::ptrdiff_t i = 0; i < len2; ++i) {
         /* Step 1: Computing D0 */
-        int64_t word = i / 64;
-        int64_t word_pos = i % 64;
+        auto word = i / 64;
+        auto word_pos = i % 64;
 
         uint64_t PM_j = PM.get(word, first2[i]) >> word_pos;
 
@@ -287,16 +287,16 @@ int64_t levenshtein_myers1999_block(const common::BlockPatternMatchVector& PM, I
         {}
     };
 
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
-    int64_t words = PM.m_val.size();
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
+    std::ptrdiff_t words = PM.m_val.size();
     int64_t currDist = len1;
 
     /* upper bound */
-    max = std::min(max, std::max(len1, len2));
+    max = std::min(max, static_cast<int64_t>(std::max(len1, len2)));
 
     // todo could safe up to 25% even without max when ignoring irrelevant paths
-    int64_t full_band = std::min(len1, 2 * max + 1);
+    int64_t full_band = std::min(static_cast<int64_t>(len1), 2 * max + 1);
 
     if (full_band <= 64) {
         return levenshtein_hyrroe2003_small_band(PM, first1, last1, first2, last2, max);
@@ -306,11 +306,11 @@ int64_t levenshtein_myers1999_block(const common::BlockPatternMatchVector& PM, I
     uint64_t Last = (uint64_t)1 << ((len1 - 1) % 64);
 
     /* Searching */
-    for (int64_t i = 0; i < len2; i++) {
+    for (std::ptrdiff_t i = 0; i < len2; i++) {
         uint64_t HP_carry = 1;
         uint64_t HN_carry = 0;
 
-        for (int64_t word = 0; word < words - 1; word++) {
+        for (std::ptrdiff_t word = 0; word < words - 1; word++) {
             /* Step 1: Computing D0 */
             uint64_t PM_j = PM.get(word, first2[i]);
             uint64_t VN = vecs[word].VN;
@@ -458,14 +458,14 @@ int64_t uniform_levenshtein_distance(InputIt1 first1, InputIt1 last1, InputIt2 f
 }
 
 struct LevenshteinBitMatrix {
-    LevenshteinBitMatrix(uint64_t rows, uint64_t cols)
+    LevenshteinBitMatrix(std::size_t rows, std::size_t cols)
         : VP(rows, cols, (uint64_t)-1), VN(rows, cols, 0), dist(0)
     {}
 
     common::Matrix<uint64_t> VP;
     common::Matrix<uint64_t> VN;
 
-    int64_t dist;
+    std::ptrdiff_t dist;
 };
 
 /**
@@ -475,9 +475,9 @@ template <typename InputIt1, typename InputIt2>
 Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                           const LevenshteinBitMatrix& matrix, StringAffix affix)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
-    int64_t dist = matrix.dist;
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
+    auto dist = matrix.dist;
     Editops editops(dist);
     editops.set_src_len(len1 + affix.prefix_len + affix.suffix_len);
     editops.set_dest_len(len2 + affix.prefix_len + affix.suffix_len);
@@ -486,14 +486,14 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
         return editops;
     }
 
-    int64_t col = len1;
-    int64_t row = len2;
+    auto col = len1;
+    auto row = len2;
 
     while (row && col) {
-        uint64_t col_pos = col - 1;
-        uint64_t col_word = col_pos / 64;
+        std::size_t col_pos = col - 1;
+        std::size_t col_word = col_pos / 64;
         col_pos = col_pos % 64;
-        uint64_t mask = 1ull << col_pos;
+        std::size_t mask = static_cast<std::size_t>(1) << col_pos;
 
         /* Deletion */
         if (matrix.VP[row - 1][col_word] & mask) {
@@ -555,8 +555,8 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003(const common::PatternMatchVec
                                                    InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                                    InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
     uint64_t VP = ~0x0ull;
     uint64_t VN = 0;
 
@@ -567,7 +567,7 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003(const common::PatternMatchVec
     uint64_t mask = (uint64_t)1 << (len1 - 1);
 
     /* Searching */
-    for (int64_t i = 0; i < len2; ++i) {
+    for (std::ptrdiff_t i = 0; i < len2; ++i) {
         /* Step 1: Computing D0 */
         uint64_t PM_j = PM.get(first2[i]);
         uint64_t X = PM_j;
@@ -597,8 +597,8 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
                                                          InputIt1 first1, InputIt1 last1,
                                                          InputIt2 first2, InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
     /* todo could be replaced with access to matrix which would slightly
      * reduce memory usage */
     struct Vectors {
@@ -609,7 +609,7 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
         {}
     };
 
-    int64_t words = PM.m_val.size();
+    std::ptrdiff_t words = PM.m_val.size();
     LevenshteinBitMatrix matrix(len2, words);
     matrix.dist = len1;
 
@@ -617,11 +617,11 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
     uint64_t Last = (uint64_t)1 << ((len1 - 1) % 64);
 
     /* Searching */
-    for (int64_t i = 0; i < len2; i++) {
+    for (std::ptrdiff_t i = 0; i < len2; i++) {
         uint64_t HP_carry = 1;
         uint64_t HN_carry = 0;
 
-        for (int64_t word = 0; word < words - 1; word++) {
+        for (std::ptrdiff_t word = 0; word < words - 1; word++) {
             /* Step 1: Computing D0 */
             uint64_t PM_j = PM.get(word, first2[i]);
             uint64_t VN = vecs[word].VN;
@@ -683,8 +683,8 @@ template <typename InputIt1, typename InputIt2>
 LevenshteinBitMatrix levenshtein_matrix(InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                         InputIt2 last2)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     if (!len1 || !len2) {
         LevenshteinBitMatrix matrix(0, 0);

--- a/rapidfuzz/distance/Levenshtein.impl
+++ b/rapidfuzz/distance/Levenshtein.impl
@@ -372,8 +372,8 @@ template <typename InputIt1, typename InputIt2>
 int64_t uniform_levenshtein_distance(const common::BlockPatternMatchVector& block, InputIt1 first1,
                                      InputIt1 last1, InputIt2 first2, InputIt2 last2, int64_t max)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     // when no differences are allowed a direct comparision is sufficient
     if (max == 0) {
@@ -416,8 +416,8 @@ template <typename InputIt1, typename InputIt2>
 int64_t uniform_levenshtein_distance(InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                      InputIt2 last2, int64_t max)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     /* Swapping the strings so the second string is shorter */
     if (len1 < len2) {
@@ -439,7 +439,7 @@ int64_t uniform_levenshtein_distance(InputIt1 first1, InputIt1 last1, InputIt2 f
     len1 = std::distance(first1, last1);
     len2 = std::distance(first2, last2);
     if (!len1 || !len2) {
-        return len1 + len2;
+        return static_cast<int64_t>(len1) + len2;
     }
 
     if (max < 4) {

--- a/rapidfuzz/distance/Levenshtein.impl
+++ b/rapidfuzz/distance/Levenshtein.impl
@@ -17,20 +17,20 @@ int64_t generalized_levenshtein_wagner_fischer(InputIt1 first1, InputIt1 last1, 
 
     cache[0] = 0;
     for (std::ptrdiff_t i = 1; i < cache_size; ++i) {
-        cache[i] = cache[i - 1] + (int64_t)weights.delete_cost;
+        cache[i] = cache[i - 1] + weights.delete_cost;
     }
 
     for (; first2 != last2; ++first2) {
         auto cache_iter = cache.begin();
         int64_t temp = *cache_iter;
-        *cache_iter += (int64_t)weights.insert_cost;
+        *cache_iter += weights.insert_cost;
 
         auto _first1 = first1;
         for (; _first1 != last1; ++_first1) {
             if (*_first1 != *first2) {
-                temp = std::min({*cache_iter + (int64_t)weights.delete_cost,
-                                 *(cache_iter + 1) + (int64_t)weights.insert_cost,
-                                 temp + (int64_t)weights.replace_cost});
+                temp = std::min({*cache_iter + weights.delete_cost,
+                                 *(cache_iter + 1) + weights.insert_cost,
+                                 temp + weights.replace_cost});
             }
             ++cache_iter;
             std::swap(*cache_iter, temp);
@@ -55,12 +55,12 @@ int64_t levenshtein_maximum(InputIt1 first1, InputIt1 last1, InputIt2 first2, In
     int64_t max_dist = len1 * weights.delete_cost + len2 * weights.insert_cost;
 
     if (len1 >= len2) {
-        max_dist = std::min(max_dist, len2 * weights.replace_cost +
-                                          (len1 - len2) * weights.delete_cost);
+        max_dist =
+            std::min(max_dist, len2 * weights.replace_cost + (len1 - len2) * weights.delete_cost);
     }
     else {
-        max_dist = std::min(max_dist, len1 * weights.replace_cost +
-                                          (len2 - len1) * weights.insert_cost);
+        max_dist =
+            std::min(max_dist, len1 * weights.replace_cost + (len2 - len1) * weights.insert_cost);
     }
 
     return max_dist;
@@ -76,8 +76,7 @@ int64_t levenshtein_min_distance(InputIt1 first1, InputIt1 last1, InputIt2 first
 {
     auto len1 = std::distance(first1, last1);
     auto len2 = std::distance(first2, last2);
-    return std::max((len1 - len2) * weights.delete_cost,
-                    (len2 - len1) * weights.insert_cost);
+    return std::max((len1 - len2) * weights.delete_cost, (len2 - len1) * weights.insert_cost);
 }
 
 template <typename InputIt1, typename InputIt2>
@@ -191,12 +190,12 @@ int64_t levenshtein_hyrroe2003(const common::PatternMatchVector& PM, InputIt1 fi
     auto len1 = std::distance(first1, last1);
 
     /* VP is set to 1^m. Shifting by bitwidth would be undefined behavior */
-    uint64_t VP = (uint64_t)-1;
+    uint64_t VP = static_cast<uint64_t>(-1);
     uint64_t VN = 0;
     int64_t currDist = len1;
 
     /* mask used when computing D[m,j] in the paper 10^(m-1) */
-    uint64_t mask = (uint64_t)1 << (len1 - 1);
+    uint64_t mask = static_cast<uint64_t>(1) << (len1 - 1);
 
     /* Searching */
     for (; first2 != last2; ++first2) {
@@ -233,7 +232,7 @@ int64_t levenshtein_hyrroe2003_small_band(const common::BlockPatternMatchVector&
     auto len2 = std::distance(first2, last2);
 
     /* VP is set to 1^m. Shifting by bitwidth would be undefined behavior */
-    uint64_t VP = (uint64_t)-1;
+    uint64_t VP = static_cast<uint64_t>(-1);
     uint64_t VN = 0;
 
     int64_t currDist = len1;
@@ -241,7 +240,7 @@ int64_t levenshtein_hyrroe2003_small_band(const common::BlockPatternMatchVector&
     /* mask used when computing D[m,j] in the paper 10^(m-1) */
     uint64_t mask = 1ull << 63;
 
-    const int64_t words = PM.m_val.size();
+    const auto words = static_cast<std::ptrdiff_t>(PM.m_val.size());
 
     /* Searching */
     for (std::ptrdiff_t i = 0; i < len2; ++i) {
@@ -289,21 +288,21 @@ int64_t levenshtein_myers1999_block(const common::BlockPatternMatchVector& PM, I
 
     auto len1 = std::distance(first1, last1);
     auto len2 = std::distance(first2, last2);
-    std::ptrdiff_t words = PM.m_val.size();
+    auto words = static_cast<std::ptrdiff_t>(PM.m_val.size());
     int64_t currDist = len1;
 
     /* upper bound */
-    max = std::min(max, static_cast<int64_t>(std::max(len1, len2)));
+    max = std::min(max, std::max<int64_t>(len1, len2));
 
     // todo could safe up to 25% even without max when ignoring irrelevant paths
-    int64_t full_band = std::min(static_cast<int64_t>(len1), 2 * max + 1);
+    int64_t full_band = std::min<int64_t>(len1, 2 * max + 1);
 
     if (full_band <= 64) {
         return levenshtein_hyrroe2003_small_band(PM, first1, last1, first2, last2, max);
     }
 
     std::vector<Vectors> vecs(words);
-    uint64_t Last = (uint64_t)1 << ((len1 - 1) % 64);
+    uint64_t Last = static_cast<uint64_t>(1) << ((len1 - 1) % 64);
 
     /* Searching */
     for (std::ptrdiff_t i = 0; i < len2; i++) {
@@ -459,7 +458,7 @@ int64_t uniform_levenshtein_distance(InputIt1 first1, InputIt1 last1, InputIt2 f
 
 struct LevenshteinBitMatrix {
     LevenshteinBitMatrix(std::size_t rows, std::size_t cols)
-        : VP(rows, cols, (uint64_t)-1), VN(rows, cols, 0), dist(0)
+        : VP(rows, cols, static_cast<uint64_t>(-1)), VN(rows, cols, 0), dist(0)
     {}
 
     common::Matrix<uint64_t> VP;
@@ -564,7 +563,7 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003(const common::PatternMatchVec
     matrix.dist = len1;
 
     /* mask used when computing D[m,j] in the paper 10^(m-1) */
-    uint64_t mask = (uint64_t)1 << (len1 - 1);
+    uint64_t mask = static_cast<uint64_t>(1) << (len1 - 1);
 
     /* Searching */
     for (std::ptrdiff_t i = 0; i < len2; ++i) {
@@ -609,12 +608,12 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
         {}
     };
 
-    std::ptrdiff_t words = PM.m_val.size();
+    auto words = static_cast<std::ptrdiff_t>(PM.m_val.size());
     LevenshteinBitMatrix matrix(len2, words);
     matrix.dist = len1;
 
     std::vector<Vectors> vecs(words);
-    uint64_t Last = (uint64_t)1 << ((len1 - 1) % 64);
+    uint64_t Last = static_cast<uint64_t>(1) << ((len1 - 1) % 64);
 
     /* Searching */
     for (std::ptrdiff_t i = 0; i < len2; i++) {
@@ -753,9 +752,9 @@ double levenshtein_normalized_distance(InputIt1 first1, InputIt1 last1, InputIt2
                                        double score_cutoff)
 {
     int64_t maximum = detail::levenshtein_maximum(first1, last1, first2, last2, weights);
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = levenshtein_distance(first1, last1, first2, last2, weights, cutoff_distance);
-    double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
+    double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 
@@ -881,9 +880,9 @@ double CachedLevenshtein<CharT1>::normalized_distance(InputIt2 first2, InputIt2 
     auto first1 = common::to_begin(s1);
     auto last1 = common::to_end(s1);
     int64_t maximum = detail::levenshtein_maximum(first1, last1, first2, last2, weights);
-    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(maximum * score_cutoff));
+    int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = distance(first2, last2, cutoff_distance);
-    double norm_dist = (maximum) ? (double)dist / (double)maximum : 0.0;
+    double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
     return (norm_dist <= score_cutoff) ? norm_dist : 1.0;
 }
 

--- a/rapidfuzz/fuzz.impl
+++ b/rapidfuzz/fuzz.impl
@@ -160,14 +160,14 @@ partial_ratio_long_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
     for (const auto& block : blocks) {
         if (block.length == len1) {
             res.score = 100;
-            res.dest_start = std::max(static_cast<std::ptrdiff_t>(0), block.dpos - block.spos);
+            res.dest_start = std::max<std::ptrdiff_t>(0, block.dpos - block.spos);
             res.dest_end = std::min(len2, res.dest_start + len1);
             return res;
         }
     }
 
     for (const auto& block : blocks) {
-        auto long_start = std::max(static_cast<std::ptrdiff_t>(0), block.dpos - block.spos);
+        auto long_start = std::max<std::ptrdiff_t>(0, block.dpos - block.spos);
         auto long_end = std::min(len2, long_start + len1);
         auto substr_first = first2 + long_start;
         auto substr_last = first2 + long_end;

--- a/rapidfuzz/fuzz.impl
+++ b/rapidfuzz/fuzz.impl
@@ -261,8 +261,8 @@ template <typename InputIt2>
 double CachedPartialRatio<CharT1>::similarity(InputIt2 first2, InputIt2 last2,
                                               double score_cutoff) const
 {
-    int64_t len1 = (int64_t)s1.size();
-    int64_t len2 = std::distance(first2, last2);
+    std::ptrdiff_t len1 = s1.size();
+    std::ptrdiff_t len2 = std::distance(first2, last2);
 
     if (len1 > len2) {
         return partial_ratio(common::to_begin(s1), common::to_end(s1), first2, last2, score_cutoff);
@@ -841,8 +841,8 @@ double WRatio(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, 
 
     constexpr double UNBASE_SCALE = 0.95;
 
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     /* in FuzzyWuzzy this returns 0. For sake of compatibility return 0 here as well
      * see https://github.com/maxbachmann/RapidFuzz/issues/110 */
@@ -898,8 +898,8 @@ double CachedWRatio<CharT1>::similarity(InputIt2 first2, InputIt2 last2, double 
 
     constexpr double UNBASE_SCALE = 0.95;
 
-    int64_t len1 = s1.size();
-    int64_t len2 = std::distance(first2, last2);
+    std::ptrdiff_t len1 = s1.size();
+    std::ptrdiff_t len2 = std::distance(first2, last2);
 
     /* in FuzzyWuzzy this returns 0. For sake of compatibility return 0 here as well
      * see https://github.com/maxbachmann/RapidFuzz/issues/110 */
@@ -945,8 +945,8 @@ double CachedWRatio<CharT1>::similarity(const Sentence2& s2, double score_cutoff
 template <typename InputIt1, typename InputIt2>
 double QRatio(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, double score_cutoff)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     /* in FuzzyWuzzy this returns 0. For sake of compatibility return 0 here as well
      * see https://github.com/maxbachmann/RapidFuzz/issues/110 */
@@ -968,7 +968,7 @@ template <typename CharT1>
 template <typename InputIt2>
 double CachedQRatio<CharT1>::similarity(InputIt2 first2, InputIt2 last2, double score_cutoff) const
 {
-    int64_t len2 = std::distance(first2, last2);
+    auto len2 = std::distance(first2, last2);
 
     /* in FuzzyWuzzy this returns 0. For sake of compatibility return 0 here as well
      * see https://github.com/maxbachmann/RapidFuzz/issues/110 */

--- a/rapidfuzz/fuzz.impl
+++ b/rapidfuzz/fuzz.impl
@@ -58,15 +58,15 @@ partial_ratio_short_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
                            double score_cutoff)
 {
     ScoreAlignment<double> res;
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
     assert(len2 >= len1);
     res.src_start = 0;
     res.src_end = len1;
     res.dest_start = 0;
     res.dest_end = len1;
 
-    for (int64_t i = 1; i < len1; ++i) {
+    for (std::ptrdiff_t i = 1; i < len1; ++i) {
         auto substr_last = first2 + i;
 
         if (!s1_char_set.find(*(substr_last - 1))) {
@@ -84,7 +84,7 @@ partial_ratio_short_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
         }
     }
 
-    for (int64_t i = 0; i < len2 - len1; ++i) {
+    for (std::ptrdiff_t i = 0; i < len2 - len1; ++i) {
         auto substr_first = first2 + i;
         auto substr_last = substr_first + len1;
 
@@ -103,7 +103,7 @@ partial_ratio_short_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
         }
     }
 
-    for (int64_t i = len2 - len1; i < len2; ++i) {
+    for (std::ptrdiff_t i = len2 - len1; i < len2; ++i) {
         auto substr_first = first2 + i;
 
         if (!s1_char_set.find(*substr_first)) {
@@ -131,8 +131,8 @@ ScoreAlignment<double> partial_ratio_short_needle(InputIt1 first1, InputIt1 last
     CachedRatio<CharT1> cached_ratio(first1, last1);
 
     common::CharSet<CharT1> s1_char_set;
-    int64_t len1 = std::distance(first1, last1);
-    for (int64_t i = 0; i < len1; ++i) {
+    auto len1 = std::distance(first1, last1);
+    for (std::ptrdiff_t i = 0; i < len1; ++i) {
         s1_char_set.insert(first1[i]);
     }
 
@@ -146,8 +146,8 @@ partial_ratio_long_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
                           const CachedRatio<CachedCharT1>& cached_ratio, double score_cutoff)
 {
     ScoreAlignment<double> res;
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
     assert(len2 >= len1);
     res.src_start = 0;
     res.src_end = len1;
@@ -160,15 +160,15 @@ partial_ratio_long_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
     for (const auto& block : blocks) {
         if (block.length == len1) {
             res.score = 100;
-            res.dest_start = std::max(int64_t(0), block.dpos - block.spos);
+            res.dest_start = std::max(static_cast<std::ptrdiff_t>(0), block.dpos - block.spos);
             res.dest_end = std::min(len2, res.dest_start + len1);
             return res;
         }
     }
 
     for (const auto& block : blocks) {
-        int64_t long_start = std::max(int64_t(0), block.dpos - block.spos);
-        int64_t long_end = std::min(len2, long_start + len1);
+        auto long_start = std::max(static_cast<std::ptrdiff_t>(0), block.dpos - block.spos);
+        auto long_end = std::min(len2, long_start + len1);
         auto substr_first = first2 + long_start;
         auto substr_last = first2 + long_end;
 
@@ -198,8 +198,8 @@ template <typename InputIt1, typename InputIt2>
 ScoreAlignment<double> partial_ratio_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                                InputIt2 last2, double score_cutoff)
 {
-    int64_t len1 = std::distance(first1, last1);
-    int64_t len2 = std::distance(first2, last2);
+    auto len1 = std::distance(first1, last1);
+    auto len2 = std::distance(first2, last2);
 
     if (len1 > len2) {
         ScoreAlignment<double> result =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,10 +37,6 @@ project_options(
         # CLANG_WARNINGS "-Weverything"
 )
 
-
-#find_package(Catch2 3 REQUIRED)
-
-
 function(rapidfuzz_add_test test)
     add_executable(test_${test} tests-${test}.cpp)
     target_link_libraries(test_${test} ${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,54 @@
-find_package(Catch2 3 REQUIRED)
+include(FetchContent)
+
+FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY  https://github.com/catchorg/Catch2.git
+        GIT_TAG         v3.0.0-preview4
+)
+
+FetchContent_MakeAvailable(Catch2)
+
+# include aminya & jason turner's C++ best practices recommended cmake project utilities
+include(FetchContent)
+FetchContent_Declare(_project_options URL https://github.com/aminya/project_options/archive/refs/tags/v0.20.0.zip)
+FetchContent_MakeAvailable(_project_options)
+include(${_project_options_SOURCE_DIR}/Index.cmake)
+
+project_options(
+        # ENABLE_CACHE
+        # ENABLE_CONAN
+        WARNINGS_AS_ERRORS
+        # ENABLE_CPPCHECK
+        # ENABLE_CLANG_TIDY
+        # ENABLE_INCLUDE_WHAT_YOU_USE
+        # ENABLE_COVERAGE
+        # ENABLE_PCH
+        # PCH_HEADERS <Eigen/Dense> <fmt/core.h> <vector> <utility> <string> <string_view>
+        # ENABLE_DOXYGEN
+        # ENABLE_IPO
+        # ENABLE_USER_LINKER
+        # ENABLE_BUILD_WITH_TIME_TRACE
+        # ENABLE_UNITY
+        # ENABLE_SANITIZER_ADDRESS
+        # ENABLE_SANITIZER_LEAK
+        # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
+        # ENABLE_SANITIZER_THREAD
+        # ENABLE_SANITIZER_MEMORY
+        # CLANG_WARNINGS "-Weverything"
+)
+
+
+#find_package(Catch2 3 REQUIRED)
+
 
 function(rapidfuzz_add_test test)
     add_executable(test_${test} tests-${test}.cpp)
     target_link_libraries(test_${test} ${PROJECT_NAME})
-    target_link_libraries(test_${test} Catch2::Catch2WithMain )
+    target_link_libraries(test_${test} Catch2::Catch2WithMain project_warnings)
     add_test(NAME ${test} COMMAND test_${test})
 endfunction()
 
 rapidfuzz_add_test(fuzz)
-rapidfuzz_add_test(common)
+#rapidfuzz_add_test(common)
 
 add_subdirectory(distance)

--- a/test/distance/CMakeLists.txt
+++ b/test/distance/CMakeLists.txt
@@ -1,16 +1,16 @@
-find_package(Catch2 3 REQUIRED)
+#find_package(Catch2 3 REQUIRED)
 
 function(rapidfuzz_add_test test)
     add_executable(test_${test} tests-${test}.cpp)
 
-    if(MSVC)
-        target_compile_options(test_${test} PRIVATE /W4 /WX)
-    else()
-        target_compile_options(test_${test} PRIVATE -Wall -Wextra -Wpedantic -Werror)
-    endif()
+#    if(MSVC)
+#        target_compile_options(test_${test} PRIVATE /W4 /WX)
+#    else()
+#        target_compile_options(test_${test} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+#    endif()
 
     target_link_libraries(test_${test} ${PROJECT_NAME})
-    target_link_libraries(test_${test} Catch2::Catch2WithMain )
+    target_link_libraries(test_${test} Catch2::Catch2WithMain project_warnings)
     add_test(NAME ${test} COMMAND test_${test})
 endfunction()
 

--- a/test/distance/CMakeLists.txt
+++ b/test/distance/CMakeLists.txt
@@ -1,14 +1,5 @@
-#find_package(Catch2 3 REQUIRED)
-
 function(rapidfuzz_add_test test)
     add_executable(test_${test} tests-${test}.cpp)
-
-#    if(MSVC)
-#        target_compile_options(test_${test} PRIVATE /W4 /WX)
-#    else()
-#        target_compile_options(test_${test} PRIVATE -Wall -Wextra -Wpedantic -Werror)
-#    endif()
-
     target_link_libraries(test_${test} ${PROJECT_NAME})
     target_link_libraries(test_${test} Catch2::Catch2WithMain project_warnings)
     add_test(NAME ${test} COMMAND test_${test})

--- a/test/distance/tests-Levenshtein.cpp
+++ b/test/distance/tests-Levenshtein.cpp
@@ -42,8 +42,8 @@ TEST_CASE("Levenshtein_editops")
 
     rapidfuzz::Editops ops = rapidfuzz::levenshtein_editops(s, d);
     REQUIRE(d == rapidfuzz::editops_apply<char>(ops, s, d));
-    REQUIRE(ops.get_src_len() == (int64_t)s.size());
-    REQUIRE(ops.get_dest_len() == (int64_t)d.size());
+    REQUIRE(ops.get_src_len() == static_cast<std::ptrdiff_t>(s.size()));
+    REQUIRE(ops.get_dest_len() == static_cast<std::ptrdiff_t>(d.size()));
 };
 
 TEST_CASE("Levenshtein_editops[fuzzing_regressions]")

--- a/test/tests-fuzz.cpp
+++ b/test/tests-fuzz.cpp
@@ -3,6 +3,8 @@
 
 #include <rapidfuzz/fuzz.hpp>
 
+#include <iostream>
+
 namespace fuzz = rapidfuzz::fuzz;
 using Catch::Approx;
 

--- a/test/tests-fuzz.cpp
+++ b/test/tests-fuzz.cpp
@@ -3,8 +3,6 @@
 
 #include <rapidfuzz/fuzz.hpp>
 
-#include <iostream>
-
 namespace fuzz = rapidfuzz::fuzz;
 using Catch::Approx;
 


### PR DESCRIPTION
As discussed [here](https://github.com/maxbachmann/rapidfuzz-cpp/discussions/67),
I have changed types of indices to `std::ptrdiff_t`. For size types that can never be negative, I changed them to `std::size_t`, including types of the corresponding indexing operators. 

Tested with MSVC 2022 ((19.30) on both 32-bit and 64-bit architecture.

I opened up this pull request to see if you think some of the changes are appropriate. Especially changes made in CMakeList.txt files, which may not be compatible and require further discussions & validations.