### PR TITLE
fix GCC and Clang warnings

### DIFF
--- a/rapidfuzz/details/SplittedSentenceView.hpp
+++ b/rapidfuzz/details/SplittedSentenceView.hpp
@@ -10,13 +10,14 @@ class SplittedSentenceView {
 public:
     using CharT = iter_value_t<InputIt>;
 
-    SplittedSentenceView(IteratorViewVec<InputIt> sentence) : m_sentence(std::move(sentence))
+    SplittedSentenceView(IteratorViewVec<InputIt> sentence)
+        noexcept(std::is_nothrow_move_constructible<IteratorViewVec<InputIt>>::value) : m_sentence(std::move(sentence))
     {}
 
-    int64_t dedupe();
-    int64_t size() const;
+    std::size_t dedupe();
+    std::size_t size() const;
 
-    int64_t length() const
+    inline std::size_t length() const
     {
         return size();
     }
@@ -26,7 +27,7 @@ public:
         return m_sentence.empty();
     }
 
-    int64_t word_count() const
+    std::size_t word_count() const
     {
         return m_sentence.size();
     }
@@ -43,22 +44,22 @@ private:
 };
 
 template <typename InputIt>
-int64_t SplittedSentenceView<InputIt>::dedupe()
+std::size_t SplittedSentenceView<InputIt>::dedupe()
 {
-    int64_t old_word_count = word_count();
+    std::size_t old_word_count = word_count();
     m_sentence.erase(std::unique(m_sentence.begin(), m_sentence.end()), m_sentence.end());
     return old_word_count - word_count();
 }
 
 template <typename InputIt>
-int64_t SplittedSentenceView<InputIt>::size() const
+std::size_t SplittedSentenceView<InputIt>::size() const
 {
     if (m_sentence.empty()) return 0;
 
     // there is a whitespace between each word
-    int64_t result = m_sentence.size() - 1;
+    std::size_t result = m_sentence.size() - 1;
     for (const auto& word : m_sentence) {
-        result += std::distance(word.first, word.last);
+        result += static_cast<std::size_t>(std::distance(word.first, word.last));
     }
 
     return result;

--- a/rapidfuzz/details/SplittedSentenceView.hpp
+++ b/rapidfuzz/details/SplittedSentenceView.hpp
@@ -17,7 +17,7 @@ public:
     std::size_t dedupe();
     std::size_t size() const;
 
-    inline std::size_t length() const
+    std::size_t length() const
     {
         return size();
     }

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -112,11 +112,11 @@ StringAffix remove_common_affix(InputIt1& first1, InputIt1& last1, InputIt2& fir
                                 InputIt2& last2);
 
 template <typename InputIt1, typename InputIt2>
-std::ptrdiff_t remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
+std::size_t remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
                                     InputIt2 last2);
 
 template <typename InputIt1, typename InputIt2>
-std::ptrdiff_t remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
+std::size_t remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
                                     InputIt2& last2);
 
 template <typename InputIt, typename CharT = iter_value_t<InputIt>>
@@ -193,7 +193,7 @@ struct PatternMatchVector {
     }
 
     template <typename CharT>
-    uint64_t get(int64_t block, CharT key) const
+    uint64_t get(std::size_t block, CharT key) const
     {
         assert(block == 0);
         (void)block;
@@ -205,11 +205,11 @@ private:
     void insert_mask(CharT key, uint64_t mask)
     {
         if (key >= 0 && key <= 255) {
-            m_extendedAscii[(uint8_t)key] |= mask;
+            m_extendedAscii[static_cast<uint8_t>(key)] |= mask;
         }
         else {
-            int32_t i = lookup(static_cast<uint64_t>(key));
-            m_map[i].key = key;
+            uint32_t i = lookup(static_cast<uint64_t>(key));
+            m_map[i].key = static_cast<uint64_t>(key);
             m_map[i].value |= mask;
         }
     }
@@ -218,9 +218,9 @@ private:
      * lookup key inside the hashmap using a similar collision resolution
      * strategy to CPython and Ruby
      */
-    int32_t lookup(uint64_t key) const
+    uint32_t lookup(uint64_t key) const
     {
-        int32_t i = key % 128;
+        uint32_t i = key % 128;
 
         if (!m_map[i].value || m_map[i].key == key) {
             return i;
@@ -250,38 +250,44 @@ struct BlockPatternMatchVector {
     }
 
     template <typename CharT>
-    void insert(int64_t block, CharT ch, int pos)
+    void insert(std::size_t block, CharT ch, int pos)
     {
         auto* be = &m_val[block];
         be->insert(ch, pos);
     }
 
+    /**
+     * @warning undefined behavior if iterator \p first is greater than \p last
+     * @tparam InputIt
+     * @param first
+     * @param last
+     */
     template <typename InputIt>
     void insert(InputIt first, InputIt last)
     {
         auto len = std::distance(first, last);
         auto block_count = len / 64 + bool(len % 64);
-        m_val.resize(block_count);
+        m_val.resize(static_cast<std::size_t>(block_count));
 
         for (std::ptrdiff_t block = 0; block < block_count; ++block) {
             if (std::distance(first + block * 64, last) > 64) {
-                m_val[block].insert(first + block * 64, first + (block + 1) * 64);
+                m_val[static_cast<std::size_t>(block)].insert(first + block * 64, first + (block + 1) * 64);
             }
             else {
-                m_val[block].insert(first + block * 64, last);
+                m_val[static_cast<std::size_t>(block)].insert(first + block * 64, last);
             }
         }
     }
 
     template <typename CharT>
-    uint64_t get(std::ptrdiff_t block, CharT ch) const
+    uint64_t get(std::size_t block, CharT ch) const
     {
         auto* be = &m_val[block];
         return be->get(ch);
     }
 };
 
-template <typename CharT1, int64_t size = sizeof(CharT1)>
+template <typename CharT1, std::size_t size = sizeof(CharT1)>
 struct CharSet;
 
 template <typename CharT1>
@@ -309,7 +315,7 @@ struct CharSet<CharT1, 1> {
     }
 };
 
-template <typename CharT1, int64_t size>
+template <typename CharT1, std::size_t size>
 struct CharSet {
     std::unordered_set<CharT1> m_val;
 

--- a/rapidfuzz/details/common_impl.hpp
+++ b/rapidfuzz/details/common_impl.hpp
@@ -50,20 +50,20 @@ std::basic_string<CharT> common::to_string(const Sentence& str)
  * Removes common prefix of two string views
  */
 template <typename InputIt1, typename InputIt2>
-std::ptrdiff_t common::remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
+std::size_t common::remove_common_prefix(InputIt1& first1, InputIt1 last1, InputIt2& first2,
                                      InputIt2 last2)
 {
     auto prefix = std::distance(first1, std::mismatch(first1, last1, first2, last2).first);
     first1 += prefix;
     first2 += prefix;
-    return prefix;
+    return static_cast<std::size_t>(prefix);
 }
 
 /**
  * Removes common suffix of two string views
  */
 template <typename InputIt1, typename InputIt2>
-std::ptrdiff_t common::remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
+std::size_t common::remove_common_suffix(InputIt1 first1, InputIt1& last1, InputIt2 first2,
                                      InputIt2& last2)
 {
     auto rfirst1 = std::make_reverse_iterator(last1);
@@ -74,7 +74,7 @@ std::ptrdiff_t common::remove_common_suffix(InputIt1 first1, InputIt1& last1, In
     auto suffix = std::distance(rfirst1, std::mismatch(rfirst1, rlast1, rfirst2, rlast2).first);
     last1 -= suffix;
     last2 -= suffix;
-    return suffix;
+    return static_cast<std::size_t>(suffix);
 }
 
 /**

--- a/rapidfuzz/details/matching_blocks.hpp
+++ b/rapidfuzz/details/matching_blocks.hpp
@@ -33,10 +33,10 @@
 namespace rapidfuzz {
 namespace detail {
 struct MatchingBlock {
-    std::ptrdiff_t spos;
-    std::ptrdiff_t dpos;
-    std::ptrdiff_t length;
-    MatchingBlock(std::ptrdiff_t aSPos, std::ptrdiff_t aDPos, std::ptrdiff_t aLength)
+    std::size_t spos;
+    std::size_t dpos;
+    std::size_t length;
+    MatchingBlock(std::size_t aSPos, std::size_t aDPos, std::size_t aLength)
         : spos(aSPos), dpos(aDPos), length(aLength)
     {}
 };
@@ -45,17 +45,17 @@ namespace difflib {
 
 template <typename InputIt1, typename InputIt2>
 class SequenceMatcher {
-    using Index = std::ptrdiff_t;
+    using Index = std::size_t;
 public:
     using match_t = std::tuple<Index, Index, Index>;
 
     SequenceMatcher(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
         : a_first(first1), a_last(last1), b_first(first2), b_last(last2)
     {
-        auto b_len = std::distance(b_first, b_last);
+        auto b_len = static_cast<std::size_t>(std::distance(b_first, b_last));
         j2len_.resize(b_len + 1);
         for (Index i = 0; i < b_len; ++i) {
-            b2j_[b_first[i]].push_back(i);
+            b2j_[b_first[static_cast<std::ptrdiff_t>(i)]].push_back(i);
         }
     }
 
@@ -69,7 +69,7 @@ public:
         {
             for (Index i = a_low; i < a_high; ++i) {
                 bool found = false;
-                auto iter = b2j_.find(a_first[i]);
+                auto iter = b2j_.find(a_first[static_cast<std::ptrdiff_t>(i)]);
                 if (iter != std::end(b2j_)) {
                     const auto& indexes = iter->second;
 
@@ -106,21 +106,21 @@ public:
                 }
 
                 if (!found) {
-                    std::fill(j2len_.begin() + b_low, j2len_.begin() + b_high, 0);
+                    std::fill(j2len_.begin() + static_cast<std::ptrdiff_t>(b_low), j2len_.begin() + static_cast<std::ptrdiff_t>(b_high), 0);
                 }
             }
 
-            std::fill(j2len_.begin() + b_low, j2len_.begin() + b_high, 0);
+            std::fill(j2len_.begin() + static_cast<std::ptrdiff_t>(b_low), j2len_.begin() + static_cast<std::ptrdiff_t>(b_high), 0);
         }
 
-        while (best_i > a_low && best_j > b_low && a_first[best_i - 1] == b_first[best_j - 1]) {
+        while (best_i > a_low && best_j > b_low && a_first[static_cast<std::ptrdiff_t>(best_i) - 1] == b_first[static_cast<std::ptrdiff_t>(best_j) - 1]) {
             --best_i;
             --best_j;
             ++best_size;
         }
 
         while ((best_i + best_size) < a_high && (best_j + best_size) < b_high &&
-               a_first[best_i + best_size] == b_first[best_j + best_size])
+               a_first[static_cast<std::ptrdiff_t>(best_i + best_size)] == b_first[static_cast<std::ptrdiff_t>(best_j + best_size)])
         {
             ++best_size;
         }
@@ -130,8 +130,8 @@ public:
 
     std::vector<MatchingBlock> get_matching_blocks()
     {
-        auto a_len = std::distance(a_first, a_last);
-        auto b_len = std::distance(b_first, b_last);
+        auto a_len = static_cast<std::size_t>(std::distance(a_first, a_last));
+        auto b_len = static_cast<std::size_t>(std::distance(b_first, b_last));
         // The following are tuple extracting aliases
         std::vector<std::tuple<Index, Index, Index, Index>> queue;
         std::vector<match_t> matching_blocks_pass1;

--- a/rapidfuzz/details/types.hpp
+++ b/rapidfuzz/details/types.hpp
@@ -63,8 +63,8 @@ template <typename InputIt>
 using IteratorViewVec = std::vector<IteratorView<InputIt>>;
 
 struct StringAffix {
-    std::ptrdiff_t prefix_len;
-    std::ptrdiff_t suffix_len;
+    std::size_t prefix_len;
+    std::size_t suffix_len;
 };
 
 struct LevenshteinWeightTable {
@@ -95,13 +95,13 @@ enum class EditType {
  */
 struct EditOp {
     EditType type;           /**< type of the edit operation */
-    std::ptrdiff_t src_pos;  /**< index into the source string */
-    std::ptrdiff_t dest_pos; /**< index into the destination string */
+    std::size_t src_pos;  /**< index into the source string */
+    std::size_t dest_pos; /**< index into the destination string */
 
     EditOp() : type(EditType::None), src_pos(0), dest_pos(0)
     {}
 
-    EditOp(EditType type_, std::ptrdiff_t src_pos_, std::ptrdiff_t dest_pos_)
+    EditOp(EditType type_, std::size_t src_pos_, std::size_t dest_pos_)
         : type(type_), src_pos(src_pos_), dest_pos(dest_pos_)
     {}
 };
@@ -126,16 +126,16 @@ inline bool operator==(EditOp a, EditOp b)
  */
 struct Opcode {
     EditType type;             /**< type of the edit operation */
-    std::ptrdiff_t src_begin;  /**< index into the source string */
-    std::ptrdiff_t src_end;    /**< index into the source string */
-    std::ptrdiff_t dest_begin; /**< index into the destination string */
-    std::ptrdiff_t dest_end;   /**< index into the destination string */
+    std::size_t src_begin;  /**< index into the source string */
+    std::size_t src_end;    /**< index into the source string */
+    std::size_t dest_begin; /**< index into the destination string */
+    std::size_t dest_end;   /**< index into the destination string */
 
     Opcode() : type(EditType::None), src_begin(0), src_end(0), dest_begin(0), dest_end(0)
     {}
 
-    Opcode(EditType type_, std::ptrdiff_t src_begin_, std::ptrdiff_t src_end_,
-           std::ptrdiff_t dest_begin_, std::ptrdiff_t dest_end_)
+    Opcode(EditType type_, std::size_t src_begin_, std::size_t src_end_,
+           std::size_t dest_begin_, std::size_t dest_end_)
         : type(type_),
           src_begin(src_begin_),
           src_end(src_end_),
@@ -174,10 +174,10 @@ void vector_slice(std::vector<T>& new_vec, const std::vector<T>& vec, int start,
         }
 
         int count = (stop - 1 - start) / step + 1;
-        new_vec.reserve(count);
+        new_vec.reserve(static_cast<std::size_t>(count));
 
         for (int i = start; i < stop; i += step) {
-            new_vec.push_back(vec[i]);
+            new_vec.push_back(vec[static_cast<std::size_t>(i)]);
         }
     }
     else if (step < 0) {
@@ -200,10 +200,10 @@ void vector_slice(std::vector<T>& new_vec, const std::vector<T>& vec, int start,
         }
 
         int count = (stop + 1 - start) / step + 1;
-        new_vec.reserve(count);
+        new_vec.reserve(static_cast<std::size_t>(count));
 
         for (int i = start; i > stop; i += step) {
-            new_vec.push_back(vec[i]);
+            new_vec.push_back(vec[static_cast<std::size_t>(i)]);
         }
     }
     else {
@@ -304,19 +304,19 @@ public:
         return reversed;
     }
 
-    std::ptrdiff_t get_src_len() const noexcept
+    std::size_t get_src_len() const noexcept
     {
         return src_len;
     }
-    void set_src_len(std::ptrdiff_t len) noexcept
+    void set_src_len(std::size_t len) noexcept
     {
         src_len = len;
     }
-    std::ptrdiff_t get_dest_len() const noexcept
+    std::size_t get_dest_len() const noexcept
     {
         return dest_len;
     }
-    void set_dest_len(std::ptrdiff_t len) noexcept
+    void set_dest_len(std::size_t len) noexcept
     {
         dest_len = len;
     }
@@ -338,8 +338,8 @@ public:
     }
 
 private:
-    std::ptrdiff_t src_len;
-    std::ptrdiff_t dest_len;
+    std::size_t src_len;
+    std::size_t dest_len;
 };
 
 inline bool operator==(const Editops& lhs, const Editops& rhs)
@@ -454,19 +454,19 @@ public:
         return reversed;
     }
 
-    std::ptrdiff_t get_src_len() const noexcept
+    std::size_t get_src_len() const noexcept
     {
         return src_len;
     }
-    void set_src_len(std::ptrdiff_t len) noexcept
+    void set_src_len(std::size_t len) noexcept
     {
         src_len = len;
     }
-    std::ptrdiff_t get_dest_len() const noexcept
+    std::size_t get_dest_len() const noexcept
     {
         return dest_len;
     }
-    void set_dest_len(std::ptrdiff_t len) noexcept
+    void set_dest_len(std::size_t len) noexcept
     {
         dest_len = len;
     }
@@ -489,8 +489,8 @@ public:
     }
 
 private:
-    std::ptrdiff_t src_len;
-    std::ptrdiff_t dest_len;
+    std::size_t src_len;
+    std::size_t dest_len;
 };
 
 inline bool operator==(const Opcodes& lhs, const Opcodes& rhs)
@@ -525,19 +525,19 @@ inline Editops::Editops(const Opcodes& other)
             break;
 
         case EditType::Replace:
-            for (std::ptrdiff_t j = 0; j < op.src_end - op.src_begin; j++) {
+            for (std::size_t j = 0; j < op.src_end - op.src_begin; j++) {
                 push_back({EditType::Replace, op.src_begin + j, op.dest_begin + j});
             }
             break;
 
         case EditType::Insert:
-            for (std::ptrdiff_t j = 0; j < op.dest_end - op.dest_begin; j++) {
+            for (std::size_t j = 0; j < op.dest_end - op.dest_begin; j++) {
                 push_back({EditType::Insert, op.src_begin, op.dest_begin + j});
             }
             break;
 
         case EditType::Delete:
-            for (std::ptrdiff_t j = 0; j < op.src_end - op.src_begin; j++) {
+            for (std::size_t j = 0; j < op.src_end - op.src_begin; j++) {
                 push_back({EditType::Delete, op.src_begin + j, op.dest_begin});
             }
             break;
@@ -549,17 +549,17 @@ inline Opcodes::Opcodes(const Editops& other)
 {
     src_len = other.get_src_len();
     dest_len = other.get_dest_len();
-    std::ptrdiff_t src_pos = 0;
-    std::ptrdiff_t dest_pos = 0;
-    for (size_t i = 0; i < other.size();) {
+    std::size_t src_pos = 0;
+    std::size_t dest_pos = 0;
+    for (std::size_t i = 0; i < other.size();) {
         if (src_pos < other[i].src_pos || dest_pos < other[i].dest_pos) {
             push_back({EditType::None, src_pos, other[i].src_pos, dest_pos, other[i].dest_pos});
             src_pos = other[i].src_pos;
             dest_pos = other[i].dest_pos;
         }
 
-        std::ptrdiff_t src_begin = src_pos;
-        std::ptrdiff_t dest_begin = dest_pos;
+        std::size_t src_begin = src_pos;
+        std::size_t dest_begin = dest_pos;
         EditType type = other[i].type;
         do {
             switch (type) {
@@ -594,16 +594,16 @@ inline Opcodes::Opcodes(const Editops& other)
 template <typename T>
 struct ScoreAlignment {
     T score;                   /**< resulting score of the algorithm */
-    std::ptrdiff_t src_start;  /**< index into the source string */
-    std::ptrdiff_t src_end;    /**< index into the source string */
-    std::ptrdiff_t dest_start; /**< index into the destination string */
-    std::ptrdiff_t dest_end;   /**< index into the destination string */
+    std::size_t src_start;  /**< index into the source string */
+    std::size_t src_end;    /**< index into the source string */
+    std::size_t dest_start; /**< index into the destination string */
+    std::size_t dest_end;   /**< index into the destination string */
 
     ScoreAlignment() : score(T()), src_start(0), src_end(0), dest_start(0), dest_end(0)
     {}
 
-    ScoreAlignment(T score_, std::ptrdiff_t src_start_, std::ptrdiff_t src_end_,
-                   std::ptrdiff_t dest_start_, std::ptrdiff_t dest_end_)
+    ScoreAlignment(T score_, std::size_t src_start_, std::size_t src_end_,
+                   std::size_t dest_start_, std::size_t dest_end_)
         : score(score_),
           src_start(src_start_),
           src_end(src_end_),

--- a/rapidfuzz/distance.hpp
+++ b/rapidfuzz/distance.hpp
@@ -13,18 +13,18 @@ template <typename CharT, typename InputIt1, typename InputIt2>
 std::basic_string<CharT> editops_apply(const Editops& ops, InputIt1 first1, InputIt1 last1,
                                        InputIt2 first2, InputIt2 last2)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
 
     std::basic_string<CharT> res_str;
     res_str.resize(len1 + len2);
-    std::ptrdiff_t src_pos = 0;
-    std::ptrdiff_t dest_pos = 0;
+    std::size_t src_pos = 0;
+    std::size_t dest_pos = 0;
 
     for (const auto& op : ops) {
         /* matches between last and current editop */
         while (src_pos < op.src_pos) {
-            res_str[dest_pos] = static_cast<CharT>(first1[src_pos]);
+            res_str[dest_pos] = static_cast<CharT>(first1[static_cast<std::ptrdiff_t>(src_pos)]);
             src_pos++;
             dest_pos++;
         }
@@ -32,12 +32,12 @@ std::basic_string<CharT> editops_apply(const Editops& ops, InputIt1 first1, Inpu
         switch (op.type) {
         case EditType::None:
         case EditType::Replace:
-            res_str[dest_pos] = static_cast<CharT>(first2[op.dest_pos]);
+            res_str[dest_pos] = static_cast<CharT>(first2[static_cast<std::ptrdiff_t>(op.dest_pos)]);
             src_pos++;
             dest_pos++;
             break;
         case EditType::Insert:
-            res_str[dest_pos] = static_cast<CharT>(first2[op.dest_pos]);
+            res_str[dest_pos] = static_cast<CharT>(first2[static_cast<std::ptrdiff_t>(op.dest_pos)]);
             dest_pos++;
             break;
         case EditType::Delete:
@@ -48,7 +48,7 @@ std::basic_string<CharT> editops_apply(const Editops& ops, InputIt1 first1, Inpu
 
     /* matches after the last editop */
     while (src_pos < len1) {
-        res_str[dest_pos] = static_cast<CharT>(first1[src_pos]);
+        res_str[dest_pos] = static_cast<CharT>(first1[static_cast<std::ptrdiff_t>(src_pos)]);
         src_pos++;
         dest_pos++;
     }
@@ -68,24 +68,24 @@ template <typename CharT, typename InputIt1, typename InputIt2>
 std::basic_string<CharT> opcodes_apply(const Opcodes& ops, InputIt1 first1, InputIt1 last1,
                                        InputIt2 first2, InputIt2 last2)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
 
     std::basic_string<CharT> res_str;
     res_str.resize(len1 + len2);
-    std::ptrdiff_t dest_pos = 0;
+    std::size_t dest_pos = 0;
 
     for (const auto& op : ops) {
         switch (op.type) {
         case EditType::None:
-            for (int64_t i = op.src_begin; i < op.src_end; ++i) {
-                res_str[dest_pos++] = static_cast<CharT>(first1[i]);
+            for (auto i = op.src_begin; i < op.src_end; ++i) {
+                res_str[dest_pos++] = static_cast<CharT>(first1[static_cast<std::ptrdiff_t>(i)]);
             }
             break;
         case EditType::Replace:
         case EditType::Insert:
-            for (int64_t i = op.dest_begin; i < op.dest_end; ++i) {
-                res_str[dest_pos++] = static_cast<CharT>(first2[i]);
+            for (auto i = op.dest_begin; i < op.dest_end; ++i) {
+                res_str[dest_pos++] = static_cast<CharT>(first2[static_cast<std::ptrdiff_t>(i)]);
             }
             break;
         case EditType::Delete:

--- a/rapidfuzz/distance/Indel.impl
+++ b/rapidfuzz/distance/Indel.impl
@@ -163,7 +163,7 @@ template <typename InputIt2>
 double CachedIndel<CharT1>::normalized_distance(InputIt2 first2, InputIt2 last2,
                                                 double score_cutoff) const
 {
-    int64_t maximum = s1.size() + std::distance(first2, last2);
+    int64_t maximum = static_cast<int64_t>(s1.size()) + std::distance(first2, last2);
     int64_t cutoff_distance = static_cast<int64_t>(std::ceil(static_cast<double>(maximum) * score_cutoff));
     int64_t dist = distance(first2, last2, cutoff_distance);
     double norm_dist = (maximum) ? static_cast<double>(dist) / static_cast<double>(maximum) : 0.0;
@@ -181,7 +181,7 @@ template <typename CharT1>
 template <typename InputIt2>
 int64_t CachedIndel<CharT1>::similarity(InputIt2 first2, InputIt2 last2, int64_t score_cutoff) const
 {
-    int64_t maximum = s1.size() + std::distance(first2, last2);
+    int64_t maximum = static_cast<int64_t>(s1.size()) + std::distance(first2, last2);
     int64_t cutoff_distance = maximum - score_cutoff;
     int64_t dist = distance(first2, last2, cutoff_distance);
     int64_t sim = maximum - dist;

--- a/rapidfuzz/distance/LCSseq.impl
+++ b/rapidfuzz/distance/LCSseq.impl
@@ -95,13 +95,13 @@ int64_t lcs_seq_mbleven2018(InputIt1 first1, InputIt1 last1, InputIt2 first2, In
     return (max_len >= score_cutoff) ? max_len : 0;
 }
 
-template <std::ptrdiff_t N, typename PMV, typename InputIt1, typename InputIt2>
+template <std::size_t N, typename PMV, typename InputIt1, typename InputIt2>
 static inline int64_t longest_common_subsequence_unroll(const PMV& block, InputIt1, InputIt1,
                                                         InputIt2 first2, InputIt2 last2,
                                                         int64_t score_cutoff)
 {
     uint64_t S[N];
-    for (int64_t i = 0; i < N; ++i) {
+    for (std::size_t i = 0; i < N; ++i) {
         S[i] = ~UINT64_C(0);
     }
 
@@ -110,7 +110,7 @@ static inline int64_t longest_common_subsequence_unroll(const PMV& block, InputI
         uint64_t Matches[N];
         uint64_t u[N];
         uint64_t x[N];
-        for (std::ptrdiff_t i = 0; i < N; ++i) {
+        for (std::size_t i = 0; i < N; ++i) {
             Matches[i] = block.get(i, *first2);
             u[i] = S[i] & Matches[i];
             x[i] = addc64(S[i], u[i], carry, &carry);
@@ -119,7 +119,7 @@ static inline int64_t longest_common_subsequence_unroll(const PMV& block, InputI
     }
 
     int64_t res = 0;
-    for (int64_t i = 0; i < N; ++i) {
+    for (std::size_t i = 0; i < N; ++i) {
         res += popcount64(~S[i]);
     }
 
@@ -132,12 +132,12 @@ longest_common_subsequence_blockwise(const common::BlockPatternMatchVector& bloc
                                      InputIt1, InputIt2 first2, InputIt2 last2,
                                      int64_t score_cutoff)
 {
-    auto words = static_cast<std::ptrdiff_t>(block.m_val.size());
+    auto words = block.m_val.size();
     std::vector<uint64_t> S(words, ~UINT64_C(0));
 
     for (; first2 != last2; ++first2) {
         uint64_t carry = 0;
-        for (std::ptrdiff_t word = 0; word < words; ++word) {
+        for (std::size_t word = 0; word < words; ++word) {
             const uint64_t Matches = block.get(word, *first2);
             uint64_t Stemp = S[word];
 
@@ -285,7 +285,7 @@ int64_t lcs_seq_similarity(const common::BlockPatternMatchVector& block, InputIt
 
     /* common affix does not effect Levenshtein distance */
     auto affix = common::remove_common_affix(first1, last1, first2, last2);
-    int64_t lcs_sim = affix.prefix_len + affix.suffix_len;
+    int64_t lcs_sim = static_cast<int64_t>(affix.prefix_len + affix.suffix_len);
     if (std::distance(first1, last1) && std::distance(first2, last2)) {
         lcs_sim += lcs_seq_mbleven2018(first1, last1, first2, last2, score_cutoff - lcs_sim);
     }
@@ -317,7 +317,7 @@ int64_t lcs_seq_similarity(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
 
     /* common affix does not effect Levenshtein distance */
     auto affix = common::remove_common_affix(first1, last1, first2, last2);
-    int64_t lcs_sim = affix.prefix_len + affix.suffix_len;
+    int64_t lcs_sim = static_cast<int64_t>(affix.prefix_len + affix.suffix_len);
     if (std::distance(first1, last1) && std::distance(first2, last2)) {
         if (max_misses < 5) {
             lcs_sim += lcs_seq_mbleven2018(first1, last1, first2, last2, score_cutoff - lcs_sim);
@@ -350,7 +350,7 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
 {
     auto len1 = std::distance(first1, last1);
     auto len2 = std::distance(first2, last2);
-    std::ptrdiff_t dist = matrix.dist;
+    auto dist = static_cast<std::size_t>(matrix.dist);
     Editops editops(dist);
     editops.set_src_len(len1 + affix.prefix_len + affix.suffix_len);
     editops.set_dest_len(len2 + affix.prefix_len + affix.suffix_len);
@@ -415,7 +415,7 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
     return editops;
 }
 
-template <std::ptrdiff_t N, typename PMV, typename InputIt1, typename InputIt2>
+template <std::size_t N, typename PMV, typename InputIt1, typename InputIt2>
 LLCSBitMatrix llcs_matrix_unroll(const PMV& block, InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                  InputIt2 last2)
 {
@@ -457,15 +457,15 @@ LLCSBitMatrix llcs_matrix_blockwise(const common::BlockPatternMatchVector& block
 {
     auto len1 = std::distance(first1, last1);
     auto len2 = std::distance(first2, last2);
-    auto words = static_cast<std::ptrdiff_t>(block.m_val.size());
+    auto words = block.m_val.size();
     /* todo could be replaced with access to matrix which would slightly
      * reduce memory usage */
     std::vector<uint64_t> S(words, ~UINT64_C(0));
     LLCSBitMatrix matrix(len2, words);
 
-    for (std::ptrdiff_t i = 0; i < len2; ++i) {
+    for (std::size_t i = 0; i < len2; ++i) {
         uint64_t carry = 0;
-        for (std::ptrdiff_t word = 0; word < words; ++word) {
+        for (std::size_t word = 0; word < words; ++word) {
             const uint64_t Matches = block.get(word, first2[i]);
             uint64_t Stemp = S[word];
 

--- a/rapidfuzz/distance/Levenshtein.impl
+++ b/rapidfuzz/distance/Levenshtein.impl
@@ -11,12 +11,19 @@ int64_t generalized_levenshtein_wagner_fischer(InputIt1 first1, InputIt1 last1, 
                                                InputIt2 last2, LevenshteinWeightTable weights,
                                                int64_t max)
 {
-    auto len1 = std::distance(first1, last1);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
     auto cache_size = len1 + 1;
     std::vector<int64_t> cache(cache_size);
 
+    // added to suppress a null pointer dereference false positive
+    // due to a bug in GCC
+#ifdef __GNUC__
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wnull-dereference"
     cache[0] = 0;
-    for (std::ptrdiff_t i = 1; i < cache_size; ++i) {
+#   pragma GCC diagnostic pop
+#endif
+    for (std::size_t i = 1; i < cache_size; ++i) {
         cache[i] = cache[i - 1] + weights.delete_cost;
     }
 
@@ -228,30 +235,30 @@ int64_t levenshtein_hyrroe2003_small_band(const common::BlockPatternMatchVector&
                                           InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                           InputIt2 last2, int64_t max)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
 
     /* VP is set to 1^m. Shifting by bitwidth would be undefined behavior */
     uint64_t VP = ~UINT64_C(0);
     uint64_t VN = 0;
 
-    int64_t currDist = len1;
+    int64_t currDist = static_cast<int64_t>(len1);
 
     /* mask used when computing D[m,j] in the paper 10^(m-1) */
     uint64_t mask = UINT64_C(1) << 63;
 
-    const auto words = static_cast<std::ptrdiff_t>(PM.m_val.size());
+    const auto words = PM.m_val.size();
 
     /* Searching */
-    for (std::ptrdiff_t i = 0; i < len2; ++i) {
+    for (std::size_t i = 0; i < len2; ++i) {
         /* Step 1: Computing D0 */
         auto word = i / 64;
         auto word_pos = i % 64;
 
-        uint64_t PM_j = PM.get(word, first2[i]) >> word_pos;
+        uint64_t PM_j = PM.get(word, first2[static_cast<std::ptrdiff_t>(i)]) >> word_pos;
 
         if (word + 1 < words && word_pos != 0) {
-            PM_j |= PM.get(word + 1, first2[i]) << (64 - word_pos);
+            PM_j |= PM.get(word + 1, first2[static_cast<std::ptrdiff_t>(i)]) << (64 - word_pos);
         }
 
         /* Step 1: Computing D0 */
@@ -288,7 +295,7 @@ int64_t levenshtein_myers1999_block(const common::BlockPatternMatchVector& PM, I
 
     auto len1 = std::distance(first1, last1);
     auto len2 = std::distance(first2, last2);
-    auto words = static_cast<std::ptrdiff_t>(PM.m_val.size());
+    auto words = PM.m_val.size();
     int64_t currDist = len1;
 
     /* upper bound */
@@ -309,7 +316,7 @@ int64_t levenshtein_myers1999_block(const common::BlockPatternMatchVector& PM, I
         uint64_t HP_carry = 1;
         uint64_t HN_carry = 0;
 
-        for (std::ptrdiff_t word = 0; word < words - 1; word++) {
+        for (std::size_t word = 0; word < words - 1; word++) {
             /* Step 1: Computing D0 */
             uint64_t PM_j = PM.get(word, first2[i]);
             uint64_t VN = vecs[word].VN;
@@ -464,7 +471,7 @@ struct LevenshteinBitMatrix {
     common::Matrix<uint64_t> VP;
     common::Matrix<uint64_t> VN;
 
-    std::ptrdiff_t dist;
+    std::size_t dist;
 };
 
 /**
@@ -474,8 +481,8 @@ template <typename InputIt1, typename InputIt2>
 Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2,
                           const LevenshteinBitMatrix& matrix, StringAffix affix)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
     auto dist = matrix.dist;
     Editops editops(dist);
     editops.set_src_len(len1 + affix.prefix_len + affix.suffix_len);
@@ -519,7 +526,7 @@ Editops recover_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
                 col--;
 
                 /* Replace (Matches are not recorded) */
-                if (first1[col] != first2[row]) {
+                if (first1[static_cast<std::ptrdiff_t>(col)] != first2[static_cast<std::ptrdiff_t>(row)]) {
                     assert(dist > 0);
                     dist--;
                     editops[dist].type = EditType::Replace;
@@ -554,8 +561,8 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003(const common::PatternMatchVec
                                                    InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                                    InputIt2 last2)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
     uint64_t VP = ~UINT64_C(0);
     uint64_t VN = 0;
 
@@ -566,9 +573,9 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003(const common::PatternMatchVec
     uint64_t mask = UINT64_C(1) << (len1 - 1);
 
     /* Searching */
-    for (std::ptrdiff_t i = 0; i < len2; ++i) {
+    for (std::size_t i = 0; i < len2; ++i) {
         /* Step 1: Computing D0 */
-        uint64_t PM_j = PM.get(first2[i]);
+        uint64_t PM_j = PM.get(first2[static_cast<std::ptrdiff_t>(i)]);
         uint64_t X = PM_j;
         uint64_t D0 = (((X & VP) + VP) ^ VP) | X | VN;
 
@@ -596,8 +603,8 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
                                                          InputIt1 first1, InputIt1 last1,
                                                          InputIt2 first2, InputIt2 last2)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
     /* todo could be replaced with access to matrix which would slightly
      * reduce memory usage */
     struct Vectors {
@@ -608,7 +615,7 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
         {}
     };
 
-    auto words = static_cast<std::ptrdiff_t>(PM.m_val.size());
+    auto words = PM.m_val.size();
     LevenshteinBitMatrix matrix(len2, words);
     matrix.dist = len1;
 
@@ -616,13 +623,13 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
     uint64_t Last = UINT64_C(1) << ((len1 - 1) % 64);
 
     /* Searching */
-    for (std::ptrdiff_t i = 0; i < len2; i++) {
+    for (std::size_t i = 0; i < len2; i++) {
         uint64_t HP_carry = 1;
         uint64_t HN_carry = 0;
 
-        for (std::ptrdiff_t word = 0; word < words - 1; word++) {
+        for (std::size_t word = 0; word < words - 1; word++) {
             /* Step 1: Computing D0 */
-            uint64_t PM_j = PM.get(word, first2[i]);
+            uint64_t PM_j = PM.get(word, first2[static_cast<std::ptrdiff_t>(i)]);
             uint64_t VN = vecs[word].VN;
             uint64_t VP = vecs[word].VP;
 
@@ -651,7 +658,7 @@ LevenshteinBitMatrix levenshtein_matrix_hyrroe2003_block(const common::BlockPatt
 
         {
             /* Step 1: Computing D0 */
-            uint64_t PM_j = PM.get(words - 1, first2[i]);
+            uint64_t PM_j = PM.get(words - 1, first2[static_cast<std::ptrdiff_t>(i)]);
             uint64_t VN = vecs[words - 1].VN;
             uint64_t VP = vecs[words - 1].VP;
 
@@ -682,8 +689,8 @@ template <typename InputIt1, typename InputIt2>
 LevenshteinBitMatrix levenshtein_matrix(InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                         InputIt2 last2)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
 
     if (!len1 || !len2) {
         LevenshteinBitMatrix matrix(0, 0);

--- a/rapidfuzz/fuzz.hpp
+++ b/rapidfuzz/fuzz.hpp
@@ -127,8 +127,8 @@ struct CachedPartialRatio {
     CachedPartialRatio(InputIt1 first1, InputIt1 last1);
 
     template <typename Sentence1>
-    CachedPartialRatio(const Sentence1& sent)
-        : CachedPartialRatio(common::to_begin(sent), common::to_end(sent))
+    CachedPartialRatio(const Sentence1& s1_)
+        : CachedPartialRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>
@@ -324,8 +324,8 @@ struct CachedTokenSetRatio {
     {}
 
     template <typename Sentence1>
-    CachedTokenSetRatio(const Sentence1& sent)
-        : CachedTokenSetRatio(common::to_begin(sent), common::to_end(sent))
+    CachedTokenSetRatio(const Sentence1& s1_)
+        : CachedTokenSetRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>
@@ -383,8 +383,8 @@ struct CachedPartialTokenSetRatio {
     {}
 
     template <typename Sentence1>
-    CachedPartialTokenSetRatio(const Sentence1& sent)
-        : CachedPartialTokenSetRatio(common::to_begin(sent), common::to_end(sent))
+    CachedPartialTokenSetRatio(const Sentence1& s1_)
+        : CachedPartialTokenSetRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>
@@ -445,8 +445,8 @@ struct CachedTokenRatio {
     {}
 
     template <typename Sentence1>
-    CachedTokenRatio(const Sentence1& sent)
-        : CachedTokenRatio(common::to_begin(sent), common::to_end(sent))
+    CachedTokenRatio(const Sentence1& s1_)
+        : CachedTokenRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>
@@ -508,8 +508,8 @@ struct CachedPartialTokenRatio {
     {}
 
     template <typename Sentence1>
-    CachedPartialTokenRatio(const Sentence1& sent)
-        : CachedPartialTokenRatio(common::to_begin(sent), common::to_end(sent))
+    CachedPartialTokenRatio(const Sentence1& s1_)
+        : CachedPartialTokenRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>
@@ -568,7 +568,7 @@ struct CachedWRatio {
     CachedWRatio(InputIt1 first1, InputIt1 last1);
 
     template <typename Sentence1>
-    CachedWRatio(const Sentence1& sent) : CachedWRatio(common::to_begin(sent), common::to_end(sent))
+    CachedWRatio(const Sentence1& s1_) : CachedWRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>
@@ -630,7 +630,7 @@ struct CachedQRatio {
     {}
 
     template <typename Sentence1>
-    CachedQRatio(const Sentence1& sent) : CachedQRatio(common::to_begin(sent), common::to_end(sent))
+    CachedQRatio(const Sentence1& s1_) : CachedQRatio(common::to_begin(s1_), common::to_end(s1_))
     {}
 
     template <typename InputIt2>

--- a/rapidfuzz/fuzz.hpp
+++ b/rapidfuzz/fuzz.hpp
@@ -127,8 +127,8 @@ struct CachedPartialRatio {
     CachedPartialRatio(InputIt1 first1, InputIt1 last1);
 
     template <typename Sentence1>
-    CachedPartialRatio(const Sentence1& s1)
-        : CachedPartialRatio(common::to_begin(s1), common::to_end(s1))
+    CachedPartialRatio(const Sentence1& sent)
+        : CachedPartialRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>
@@ -324,8 +324,8 @@ struct CachedTokenSetRatio {
     {}
 
     template <typename Sentence1>
-    CachedTokenSetRatio(const Sentence1& s1)
-        : CachedTokenSetRatio(common::to_begin(s1), common::to_end(s1))
+    CachedTokenSetRatio(const Sentence1& sent)
+        : CachedTokenSetRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>
@@ -383,8 +383,8 @@ struct CachedPartialTokenSetRatio {
     {}
 
     template <typename Sentence1>
-    CachedPartialTokenSetRatio(const Sentence1& s1)
-        : CachedPartialTokenSetRatio(common::to_begin(s1), common::to_end(s1))
+    CachedPartialTokenSetRatio(const Sentence1& sent)
+        : CachedPartialTokenSetRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>
@@ -445,8 +445,8 @@ struct CachedTokenRatio {
     {}
 
     template <typename Sentence1>
-    CachedTokenRatio(const Sentence1& s1)
-        : CachedTokenRatio(common::to_begin(s1), common::to_end(s1))
+    CachedTokenRatio(const Sentence1& sent)
+        : CachedTokenRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>
@@ -508,8 +508,8 @@ struct CachedPartialTokenRatio {
     {}
 
     template <typename Sentence1>
-    CachedPartialTokenRatio(const Sentence1& s1)
-        : CachedPartialTokenRatio(common::to_begin(s1), common::to_end(s1))
+    CachedPartialTokenRatio(const Sentence1& sent)
+        : CachedPartialTokenRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>
@@ -568,7 +568,7 @@ struct CachedWRatio {
     CachedWRatio(InputIt1 first1, InputIt1 last1);
 
     template <typename Sentence1>
-    CachedWRatio(const Sentence1& s1) : CachedWRatio(common::to_begin(s1), common::to_end(s1))
+    CachedWRatio(const Sentence1& sent) : CachedWRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>
@@ -630,7 +630,7 @@ struct CachedQRatio {
     {}
 
     template <typename Sentence1>
-    CachedQRatio(const Sentence1& s1) : CachedQRatio(common::to_begin(s1), common::to_end(s1))
+    CachedQRatio(const Sentence1& sent) : CachedQRatio(common::to_begin(sent), common::to_end(sent))
     {}
 
     template <typename InputIt2>

--- a/rapidfuzz/fuzz.impl
+++ b/rapidfuzz/fuzz.impl
@@ -58,16 +58,16 @@ partial_ratio_short_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
                            double score_cutoff)
 {
     ScoreAlignment<double> res;
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
     assert(len2 >= len1);
     res.src_start = 0;
     res.src_end = len1;
     res.dest_start = 0;
     res.dest_end = len1;
 
-    for (std::ptrdiff_t i = 1; i < len1; ++i) {
-        auto substr_last = first2 + i;
+    for (std::size_t i = 1; i < len1; ++i) {
+        auto substr_last = first2 + static_cast<std::ptrdiff_t>(i);
 
         if (!s1_char_set.find(*(substr_last - 1))) {
             continue;
@@ -84,9 +84,9 @@ partial_ratio_short_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
         }
     }
 
-    for (std::ptrdiff_t i = 0; i < len2 - len1; ++i) {
-        auto substr_first = first2 + i;
-        auto substr_last = substr_first + len1;
+    for (std::size_t i = 0; i < len2 - len1; ++i) {
+        auto substr_first = first2 + static_cast<std::ptrdiff_t>(i);
+        auto substr_last = substr_first + static_cast<std::ptrdiff_t>(len1);
 
         if (!s1_char_set.find(*(substr_last - 1))) {
             continue;
@@ -103,8 +103,8 @@ partial_ratio_short_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inp
         }
     }
 
-    for (std::ptrdiff_t i = len2 - len1; i < len2; ++i) {
-        auto substr_first = first2 + i;
+    for (std::size_t i = len2 - len1; i < len2; ++i) {
+        auto substr_first = first2 + static_cast<std::ptrdiff_t>(i);
 
         if (!s1_char_set.find(*substr_first)) {
             continue;
@@ -146,8 +146,8 @@ partial_ratio_long_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
                           const CachedRatio<CachedCharT1>& cached_ratio, double score_cutoff)
 {
     ScoreAlignment<double> res;
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
     assert(len2 >= len1);
     res.src_start = 0;
     res.src_end = len1;
@@ -160,17 +160,17 @@ partial_ratio_long_needle(InputIt1 first1, InputIt1 last1, InputIt2 first2, Inpu
     for (const auto& block : blocks) {
         if (block.length == len1) {
             res.score = 100;
-            res.dest_start = std::max<std::ptrdiff_t>(0, block.dpos - block.spos);
+            res.dest_start = std::max<std::size_t>(0, block.dpos - block.spos);
             res.dest_end = std::min(len2, res.dest_start + len1);
             return res;
         }
     }
 
     for (const auto& block : blocks) {
-        auto long_start = std::max<std::ptrdiff_t>(0, block.dpos - block.spos);
+        auto long_start = std::max<std::size_t>(0, block.dpos - block.spos);
         auto long_end = std::min(len2, long_start + len1);
-        auto substr_first = first2 + long_start;
-        auto substr_last = first2 + long_end;
+        auto substr_first = first2 + static_cast<std::ptrdiff_t>(long_start);
+        auto substr_last = first2 + static_cast<std::ptrdiff_t>(long_end);
 
         double ls_ratio = cached_ratio.similarity(substr_first, substr_last, score_cutoff);
         if (ls_ratio > res.score) {
@@ -198,8 +198,8 @@ template <typename InputIt1, typename InputIt2>
 ScoreAlignment<double> partial_ratio_alignment(InputIt1 first1, InputIt1 last1, InputIt2 first2,
                                                InputIt2 last2, double score_cutoff)
 {
-    auto len1 = std::distance(first1, last1);
-    auto len2 = std::distance(first2, last2);
+    auto len1 = static_cast<std::size_t>(std::distance(first1, last1));
+    auto len2 = static_cast<std::size_t>(std::distance(first2, last2));
 
     if (len1 > len2) {
         ScoreAlignment<double> result =
@@ -261,8 +261,8 @@ template <typename InputIt2>
 double CachedPartialRatio<CharT1>::similarity(InputIt2 first2, InputIt2 last2,
                                               double score_cutoff) const
 {
-    std::ptrdiff_t len1 = s1.size();
-    std::ptrdiff_t len2 = std::distance(first2, last2);
+    std::size_t len1 = s1.size();
+    std::size_t len2 = static_cast<std::size_t>(std::distance(first2, last2));
 
     if (len1 > len2) {
         return partial_ratio(common::to_begin(s1), common::to_end(s1), first2, last2, score_cutoff);
@@ -400,13 +400,13 @@ double token_set_ratio(const SplittedSentenceView<InputIt1>& tokens_a,
     auto diff_ab_joined = diff_ab.join();
     auto diff_ba_joined = diff_ba.join();
 
-    int64_t ab_len = diff_ab_joined.length();
-    int64_t ba_len = diff_ba_joined.length();
-    int64_t sect_len = intersect.length();
+    std::size_t ab_len = diff_ab_joined.length();
+    std::size_t ba_len = diff_ba_joined.length();
+    std::size_t sect_len = intersect.length();
 
     // string length sect+ab <-> sect and sect+ba <-> sect
-    int64_t sect_ab_len = sect_len + bool(sect_len) + ab_len;
-    int64_t sect_ba_len = sect_len + bool(sect_len) + ba_len;
+    int64_t sect_ab_len = static_cast<int64_t>(sect_len + bool(sect_len) + ab_len);
+    int64_t sect_ba_len = static_cast<int64_t>(sect_len + bool(sect_len) + ba_len);
 
     double result = 0;
     auto cutoff_distance = common::score_cutoff_to_distance<100>(score_cutoff, sect_ab_len + sect_ba_len);
@@ -424,13 +424,13 @@ double token_set_ratio(const SplittedSentenceView<InputIt1>& tokens_a,
     // levenshtein distance sect+ab <-> sect and sect+ba <-> sect
     // since only sect is similar in them the distance can be calculated based on
     // the length difference
-    int64_t sect_ab_dist = bool(sect_len) + ab_len;
+    int64_t sect_ab_dist = static_cast<int64_t>(bool(sect_len) + ab_len);
     double sect_ab_ratio =
-        common::norm_distance<100>(sect_ab_dist, sect_len + sect_ab_len, score_cutoff);
+        common::norm_distance<100>(sect_ab_dist, static_cast<int64_t>(sect_len) + sect_ab_len, score_cutoff);
 
-    int64_t sect_ba_dist = bool(sect_len) + ba_len;
+    int64_t sect_ba_dist = static_cast<int64_t>(bool(sect_len) + ba_len);
     double sect_ba_ratio =
-        common::norm_distance<100>(sect_ba_dist, sect_len + sect_ba_len, score_cutoff);
+        common::norm_distance<100>(sect_ba_dist, static_cast<int64_t>(sect_len) + sect_ba_len, score_cutoff);
 
     return std::max({result, sect_ab_ratio, sect_ba_ratio});
 }
@@ -557,15 +557,15 @@ double token_ratio(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 la
     auto diff_ab_joined = diff_ab.join();
     auto diff_ba_joined = diff_ba.join();
 
-    int64_t ab_len = diff_ab_joined.length();
-    int64_t ba_len = diff_ba_joined.length();
-    int64_t sect_len = intersect.length();
+    std::size_t ab_len = diff_ab_joined.length();
+    std::size_t ba_len = diff_ba_joined.length();
+    std::size_t sect_len = intersect.length();
 
     double result = ratio(tokens_a.join(), tokens_b.join(), score_cutoff);
 
     // string length sect+ab <-> sect and sect+ba <-> sect
-    int64_t sect_ab_len = sect_len + bool(sect_len) + ab_len;
-    int64_t sect_ba_len = sect_len + bool(sect_len) + ba_len;
+    int64_t sect_ab_len = static_cast<int64_t>(sect_len + bool(sect_len) + ab_len);
+    int64_t sect_ba_len = static_cast<int64_t>(sect_len + bool(sect_len) + ba_len);
 
     auto cutoff_distance = common::score_cutoff_to_distance<100>(score_cutoff, sect_ab_len + sect_ba_len);
     int64_t dist = indel_distance(diff_ab_joined, diff_ba_joined, cutoff_distance);
@@ -582,13 +582,13 @@ double token_ratio(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 la
     // levenshtein distance sect+ab <-> sect and sect+ba <-> sect
     // since only sect is similar in them the distance can be calculated based on
     // the length difference
-    int64_t sect_ab_dist = bool(sect_len) + ab_len;
+    int64_t sect_ab_dist = static_cast<int64_t>(bool(sect_len) + ab_len);
     double sect_ab_ratio =
-        common::norm_distance<100>(sect_ab_dist, sect_len + sect_ab_len, score_cutoff);
+        common::norm_distance<100>(sect_ab_dist, static_cast<int64_t>(sect_len) + sect_ab_len, score_cutoff);
 
-    int64_t sect_ba_dist = bool(sect_len) + ba_len;
+    int64_t sect_ba_dist = static_cast<int64_t>(bool(sect_len) + ba_len);
     double sect_ba_ratio =
-        common::norm_distance<100>(sect_ba_dist, sect_len + sect_ba_len, score_cutoff);
+        common::norm_distance<100>(sect_ba_dist, static_cast<int64_t>(sect_len) + sect_ba_len, score_cutoff);
 
     return std::max({result, sect_ab_ratio, sect_ba_ratio});
 }

--- a/test/distance/tests-Levenshtein.cpp
+++ b/test/distance/tests-Levenshtein.cpp
@@ -42,8 +42,8 @@ TEST_CASE("Levenshtein_editops")
 
     rapidfuzz::Editops ops = rapidfuzz::levenshtein_editops(s, d);
     REQUIRE(d == rapidfuzz::editops_apply<char>(ops, s, d));
-    REQUIRE(ops.get_src_len() == static_cast<std::ptrdiff_t>(s.size()));
-    REQUIRE(ops.get_dest_len() == static_cast<std::ptrdiff_t>(d.size()));
+    REQUIRE(ops.get_src_len() == s.size());
+    REQUIRE(ops.get_dest_len() == d.size());
 };
 
 TEST_CASE("Levenshtein_editops[fuzzing_regressions]")

--- a/test/tests-fuzz.cpp
+++ b/test/tests-fuzz.cpp
@@ -150,7 +150,6 @@ TEST_CASE("RatioTest")
 
     SECTION("testIssue206") /* test for https://github.com/maxbachmann/RapidFuzz/issues/206 */
     {
-        double score1, score2;
         const char* str1 = "South Korea";
         const char* str2 = "North Korea";
 
@@ -165,7 +164,6 @@ TEST_CASE("RatioTest")
 
     SECTION("testIssue210") /* test for https://github.com/maxbachmann/RapidFuzz/issues/210 */
     {
-        double score1, score2;
         const char* str1 = "bc";
         const char* str2 = "bca";
 


### PR DESCRIPTION
1. change most of the indexing types from std::ptrdiff_t to std::size_t
2. fix GCC -Wshadow warnings
3. fix a GCC -Wnull-dereference false positive by suppressing the error
