### PR TITLE
Avoid incrementing the "last" iterator in `sorted_split`

### DIFF
--- a/rapidfuzz/details/common_impl.hpp
+++ b/rapidfuzz/details/common_impl.hpp
@@ -174,7 +174,7 @@ SplittedSentenceView<InputIt> common::sorted_split(InputIt first, InputIt last)
     IteratorViewVec<InputIt> splitted;
     auto second = first;
 
-    for (; second != last && first != last; first = second + 1) {
+    for (; first != last; first = second + 1) {
         second = std::find_if(first, last, is_space<CharT>);
 
         if (first != second) {

--- a/rapidfuzz/details/common_impl.hpp
+++ b/rapidfuzz/details/common_impl.hpp
@@ -180,6 +180,9 @@ SplittedSentenceView<InputIt> common::sorted_split(InputIt first, InputIt last)
         if (first != second) {
             splitted.emplace_back(first, second);
         }
+
+        if (second == last)
+            break;
     }
 
     std::sort(splitted.begin(), splitted.end());


### PR DESCRIPTION
This is a fix for the issue #74, where the iterator `second`, being equal to the `last`, is incremented, causing a runtime assertion

`test_fuzz` passes in both Debug and Release configuration
All other tests pass in Release (Levenshtein fails in Debug, even before this PR)