### PR TITLE
Fix build with GCC 13

### DIFF
--- a/test/distance/examples/ocr.hpp
+++ b/test/distance/examples/ocr.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 
 extern std::basic_string<uint8_t> ocr_example1;


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895696