### PR TITLE
Fix CMake export error when added as sub directory by offering installation option

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -103,6 +103,10 @@ jobs:
 
   build_cmake_subdir:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        BUILD_TYPE: [Release, Debug]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,6 +101,36 @@ jobs:
       working-directory: examples/cmake_installed/build
       run: ./foo
 
+  build_cmake_subdir:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure the library dependent on RapidFuzz
+      working-directory: examples/cmake_export
+      run: cmake -B build -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}}
+
+    - name: Build the library dependent on RapidFuzz
+      working-directory: examples/cmake_export
+      run: cmake --build build --config ${{matrix.BUILD_TYPE}}
+
+    - name: Install the library dependent on RapidFuzz
+      working-directory: examples/cmake_export
+      run: sudo cmake --build build --target install
+
+    - name: Configure the app indirectly dependent on RapidFuzz
+      working-directory: examples/cmake_export/indirect_app
+      run: cmake -B build -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}}
+
+    - name: Build the app indirectly dependent on RapidFuzz
+      working-directory: examples/cmake_export/indirect_app
+      run: cmake --build build --config ${{matrix.BUILD_TYPE}}
+
+    - name: Run the app indirectly dependent on RapidFuzz
+      working-directory: examples/cmake_export/indirect_app/build
+      run: ./fooapp
+
   build_cpack_installed:
     runs-on: ubuntu-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,15 @@ endif()
 # disable testsuite in that case
 if(NOT DEFINED PROJECT_NAME)
   set(NOT_SUBPROJECT ON)
+  # If RapidFuzz is not being used as a subproject via `add_subdirectory`,
+  # usually installation is required
+  option(RAPIDFUZZ_INSTALL "Install rapidfuzz" ON)
 else()
   set(NOT_SUBPROJECT OFF)
+  # If RapidFuzz is being used as a subproject via `add_subdirectory`,
+  # chances are that the "main project" does not include RapidFuzz headers
+  # in any of its headers, in which case installation is not needed.
+  option(RAPIDFUZZ_INSTALL "Install rapidfuzz (Projects embedding rapidfuzz may want to turn this OFF.)" OFF)
 endif()
 
 option(RAPIDFUZZ_BUILD_TESTING "Build tests" OFF)
@@ -73,9 +80,7 @@ if(RAPIDFUZZ_BUILD_FUZZERS)
     add_subdirectory(fuzzing)
 endif()
 
-# Only perform the installation steps when RapidFuzz is not being used as
-# a subproject via `add_subdirectory`
-if (NOT_SUBPROJECT)
+if (RAPIDFUZZ_INSTALL)
     set(RAPIDFUZZ_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/rapidfuzz")
 
     install(
@@ -135,4 +140,4 @@ if (NOT_SUBPROJECT)
     set(CPACK_PACKAGE_CONTACT "https://github.com/maxbachmann/rapidfuzz-cpp")
     include(CPack)
 
-endif(NOT_SUBPROJECT)
+endif(RAPIDFUZZ_INSTALL)

--- a/README.md
+++ b/README.md
@@ -98,9 +98,15 @@ It will be downloaded each time you run CMake in a blank folder.
 
 There are CMake options available:
 
-1. `BUILD_TESTS` : to build test (default OFF and requires [Catch2](https://github.com/catchorg/Catch2))
-
-2. `BUILD_BENCHMARKS` : to build benchmarks (default OFF and requires [Google Benchmark](https://github.com/google/benchmark))
+1. `RAPIDFUZZ_BUILD_TESTING` : to build test (default OFF and requires [Catch2](https://github.com/catchorg/Catch2))
+2. `RAPIDFUZZ_BUILD_BENCHMARKS` : to build benchmarks (default OFF and requires [Google Benchmark](https://github.com/google/benchmark))
+3. `RAPIDFUZZ_INSTALL` : to install the library to local computer
+    - When configured independently, installation is on.
+    - When used as a subproject, the installation is turned off by default.
+    - For library developers, you might want to toggle the behavior depending on your project.
+    - If your project is exported via `CMake`, turn installation on or export error will result.
+    - If your project publicly depends on `RapidFuzz` (includes `rapidfuzz.hpp` in header),
+      turn installation on or apps depending on your project would face include errors.
 
 ## Usage
 ```cpp

--- a/examples/cmake_export/CMakeLists.txt
+++ b/examples/cmake_export/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(foo LANGUAGES CXX VERSION 0.0.1)
 
+# The example library publicly dependent on RapidFuzz (includes
+# rapidfuzz.hpp in foo_lib.hpp), necessitating RapidFuzz's installation
+set(RAPIDFUZZ_INSTALL ON CACHE INTERNAL "")
 add_subdirectory(${CMAKE_SOURCE_DIR}/../..
                  ${CMAKE_SOURCE_DIR}/../../build)
+
 add_library(foo foo_lib.cc)
 add_library(foo::foo ALIAS foo)
 target_link_libraries(foo rapidfuzz)

--- a/examples/cmake_export/CMakeLists.txt
+++ b/examples/cmake_export/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.5)
+project(foo LANGUAGES CXX VERSION 0.0.1)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/../..
+                 ${CMAKE_SOURCE_DIR}/../../build)
+add_library(foo foo_lib.cc)
+add_library(foo::foo ALIAS foo)
+target_link_libraries(foo rapidfuzz)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(FOO_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/foo")
+install(TARGETS foo EXPORT fooTargs DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(EXPORT fooTargs NAMESPACE foo:: DESTINATION ${FOO_CMAKE_CONFIG_DESTINATION})
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    INSTALL_DESTINATION ${FOO_CMAKE_CONFIG_DESTINATION}
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION
+    ${FOO_CMAKE_CONFIG_DESTINATION}
+)
+install(FILES foo_lib.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/examples/cmake_export/fooConfig.cmake.in
+++ b/examples/cmake_export/fooConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+# Avoid repeatedly including the targets
+if(NOT TARGET foo::foo)
+    find_package(rapidfuzz REQUIRED)
+    # Provide path for scripts
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+    include(${CMAKE_CURRENT_LIST_DIR}/fooTargs.cmake)
+endif()

--- a/examples/cmake_export/foo_lib.cc
+++ b/examples/cmake_export/foo_lib.cc
@@ -1,0 +1,7 @@
+#include "foo_lib.hpp"
+
+double fooFunc() {
+    std::string_view a("aaaa"), b("abaa");
+    FooType cache(a.begin(), a.end());
+    return cache.similarity(b);
+}

--- a/examples/cmake_export/foo_lib.hpp
+++ b/examples/cmake_export/foo_lib.hpp
@@ -1,0 +1,4 @@
+#include <rapidfuzz/fuzz.hpp>
+
+using FooType = rapidfuzz::fuzz::CachedRatio<char>;
+double fooFunc();

--- a/examples/cmake_export/indirect_app/CMakeLists.txt
+++ b/examples/cmake_export/indirect_app/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+project(fooapp LANGUAGES CXX VERSION 0.0.1)
+find_package(foo REQUIRED)
+add_executable(fooapp foo_app.cc)
+target_link_libraries(fooapp foo::foo)

--- a/examples/cmake_export/indirect_app/foo_app.cc
+++ b/examples/cmake_export/indirect_app/foo_app.cc
@@ -1,0 +1,7 @@
+#include <iostream>
+#include <foo_lib.hpp>
+
+int main() {
+    std::cout << fooFunc() << '\n';
+    return 0;
+}


### PR DESCRIPTION
Resolves #106 

Similar to `GoogleTest`, an option on whether the package shall be installed is provided, so that authors of libraries reliant on `RapidFuzz` could opt for `RapidFuzz`'s installation based on their needs.  
The option's default value respects original versions of `RapidFuzz`: enabled by default if it is not a subproject, disabled otherwise, therefore all existing libraries using `RapidFuzz` will not break, and all existing tests in workflow should pass.

Instructions on how to configure this new option is added in `README.md`.

A new workflow is added to test this option, exporting an example library publicly dependent on `RapidFuzz` and compiling an example application linked against that example library.  
Other workflows remain untouched.
