### PR TITLE
fix cmake_minimum_required syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Cmake config largely taken from catch2
-cmake_minimum_required(VERSION 3.5..3.31)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
   cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
Fix syntax to avoid warning on newer versions of cmake