### PR TITLE
fix: Add missing standard library includes in Range.hpp and GrowingHashmap.hpp

### DIFF
--- a/rapidfuzz/details/GrowingHashmap.hpp
+++ b/rapidfuzz/details/GrowingHashmap.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <utility>
 #include <array>
 #include <stddef.h>
 #include <stdint.h>

--- a/rapidfuzz/details/Range.hpp
+++ b/rapidfuzz/details/Range.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <utility>
 #include <cassert>
 #include <cstddef>
 #include <iterator>


### PR DESCRIPTION
Some template and utility helpers (e.g., `std::copy`, `std::equal`, `std::distance`, `std::swap`) are referenced in header files without explicitly importing `<algorithm>` or `<utility>`. 

This works transitively when parsing implementation/benchmark targets, but breaks under strict compiler toolchains that validate header files in isolation (such as modern prepended headers or module parses).

Specifically:
- `rapidfuzz/details/GrowingHashmap.hpp` requires `#include <algorithm>` and `#include <utility>` for `std::swap` and `std::copy`.
- `rapidfuzz/details/Range.hpp` requires `#include <algorithm>` and `#include <utility>` for `std::equal`, `std::lexicographical_compare`, and standard iterator helpers.

This patch resolved these issues by explicitly adding the required self-contained standard library header inclusions.
